### PR TITLE
Modifications needed to run Mirador viewer component in a tabbed div

### DIFF
--- a/js/components/MiradorContainer.js
+++ b/js/components/MiradorContainer.js
@@ -1,13 +1,10 @@
 import React from "react";
 
-import Image from "./Image";
-import miradorLarge from "./images/mirador-3-1.png";
-
-//import MiradorViewer from './MiradorViewer';
+import MiradorViewer from './MiradorViewer';
 
 const MiradorContainer = () => {
-  return <Image src={miradorLarge} width={1175} height={797} />;
-  //return <MiradorViewer />;
+  //return <Image src={miradorLarge} width={1175} height={797} />;
+  return <MiradorViewer />;
 };
 
 export default MiradorContainer;

--- a/js/components/MiradorContainer.js
+++ b/js/components/MiradorContainer.js
@@ -3,7 +3,6 @@ import React from "react";
 import MiradorViewer from './MiradorViewer';
 
 const MiradorContainer = () => {
-  //return <Image src={miradorLarge} width={1175} height={797} />;
   return <MiradorViewer />;
 };
 

--- a/js/components/MiradorViewer.jsx
+++ b/js/components/MiradorViewer.jsx
@@ -1,7 +1,10 @@
-import React, { Component } from "react";
-//import PropTypes from "prop-types";
+import React, { Component } from 'react';
+//import PropTypes from 'prop-types';
+
+import "./MiradorViewer.css";
 
 export default class MiradorViewer extends Component {
+
   // constructor(props) {
   //   super(props);
   // }
@@ -9,64 +12,35 @@ export default class MiradorViewer extends Component {
   componentDidMount() {
     Mirador({
       id: "mirador",
-      layout: "1x2",
-      buildPath: "/mirador/",
+      layout: "1x1",
+      buildPath: "mirador/",
       data: [
-        {
-          manifestUri:
-            "http://iiif.harvardartmuseums.org/manifests/object/299843",
-          location: "Harvard University"
-        },
-        {
-          manifestUri:
-            "http://iiif.harvardartmuseums.org/manifests/object/304136",
-          location: "Harvard University"
-        },
-        {
-          manifestUri:
-            "http://iiif.harvardartmuseums.org/manifests/object/198021",
-          location: "Harvard University"
-        },
-        {
-          manifestUri:
-            "http://iiif.harvardartmuseums.org/manifests/object/320567",
-          location: "Harvard University"
-        },
-        {
-          manifestUri:
-            "http://media.nga.gov/public/manifests/nga_highlights.json",
-          location: "National Gallery of Art"
-        },
-        {
-          manifestUri:
-            "https://media.nga.gov/public/manifests/multispectral_demo.json",
-          location: "National Gallery of Art"
-        }
+        { manifestUri: "https://iiif.harvardartmuseums.org/manifests/object/299843", "location": "Harvard University"},
+        { manifestUri: "https://iiif.harvardartmuseums.org/manifests/object/304136", "location": "Harvard University"},
+        { manifestUri: "https://iiif.harvardartmuseums.org/manifests/object/198021", "location": "Harvard University"},
+        { manifestUri: "https://iiif.harvardartmuseums.org/manifests/object/320567", "location": "Harvard University"},
+        { manifestUri: "https://media.nga.gov/public/manifests/nga_highlights.json", "location": "National Gallery of Art"},
+        { manifestUri: "https://media.nga.gov/public/manifests/multispectral_demo.json", "location": "National Gallery of Art"},
       ],
-      windowObjects: [
-        {
-          loadedManifest:
-            "http://iiif.harvardartmuseums.org/manifests/object/299843",
-          viewType: "ImageView",
-          slotAddress: "row1.column1"
-        },
-        {
-          loadedManifest:
-            "http://media.nga.gov/public/manifests/nga_highlights.json",
-          slotAddress: "row1.column2",
-          viewType: "ImageView"
-        }
-      ],
+      windowObjects: [{
+        loadedManifest: "https://iiif.harvardartmuseums.org/manifests/object/299843",
+        viewType: "ImageView"
+        //slotAddress: "row1.column1"
+      }/*,{
+        loadedManifest: "https://media.nga.gov/public/manifests/nga_highlights.json",
+        slotAddress: "row1.column2",
+        viewType: "ImageView"
+      }*/],
       annotationEndpoint: {
         name: "Local Storage",
         module: "LocalStorageEndpoint"
       },
       windowSettings: {
         canvasControls: {
-          imageManipulation: {
-            manipulationLayer: true,
-            controls: {
-              mirror: true
+          imageManipulation : {
+            manipulationLayer : true,
+            controls : {
+              mirror : true
             }
           }
         }
@@ -75,7 +49,9 @@ export default class MiradorViewer extends Component {
   }
 
   render() {
-    return <div id="mirador" />;
+    return (
+      <div id="mirador"></div>
+    );
   }
 }
 

--- a/js/index.jsx
+++ b/js/index.jsx
@@ -3,8 +3,6 @@ import ReactDOM from "react-dom";
 //import "./components/index.css";
 import App from "./components/App";
 
-//import MiradorViewer from './components/MiradorViewer';
-
 ReactDOM.render(<App />, document.getElementById("app"));
 
 module.hot.accept();


### PR DESCRIPTION
The primary change is the addition of the MiradorViewer.css file (which managed to sneak in on a different PR). This CSS sets the .mirador-viewer height parameter to 100% of the visible window. Mirador expects to have the full window and thus doesn't set this value, with the result that when it's loaded in a div, the height of the image viewer window defaults to 0. Setting the height to 100vh seemed the best way to get around this without hard-coding actual pixel values.

Also included are some changes to the MiradorViewer.jsx component to make it look a little better -- though this section of the code remains in flux.