### PR TITLE
Image crop api (possibly WIP)

### DIFF
--- a/js/components/App.js
+++ b/js/components/App.js
@@ -137,8 +137,6 @@ class App extends Component {
 
         for (let coords of coordsData) {
           let msID = coords.page.manuscript;
-          let pageID = coords.page.id;
-          let pageURL = coords.page.url;
 
           let ltID = coords.letter;
 
@@ -155,8 +153,10 @@ class App extends Component {
 
           if (coords.binary_url !== null) {
             let letterInstance = {
-              page: pageID,
-              pageurl: pageURL,
+              page: coords.page.id,
+              pageurl: coords.page.url,
+              pagewidth: coords.page.width,
+              pageheight: coords.page.height,
               letter: ltID,
               binaryurl: coords.binary_url,
               id: coords.id,

--- a/js/components/App.js
+++ b/js/components/App.js
@@ -37,7 +37,7 @@ import DashTabs from "./DashTabs";
 /* The maximum number of letter examples to load (and possibly show) */
 const MAX_EXAMPLES = 5;
 
-const API_ROOT = "https://db.syriac.reclaim.hosting/api/";
+export const API_ROOT = "https://db.syriac.reclaim.hosting/api/";
 //const API_ROOT = "http://localhost:8000/api/";
 
 class App extends Component {

--- a/js/components/LetterImage.js
+++ b/js/components/LetterImage.js
@@ -11,11 +11,18 @@ const SMALL_DIM = 25;
 const MEDIUM_DIM = 50;
 const LARGE_DIM = 100;
 
+const SMALL_MARGIN = 10;
+const MEDIUM_MARGIN = 20;
+const LARGE_MARGIN = 30;
+
 class LetterImage extends React.Component {
   constructor(props) {
     super(props);
 
+    this.state = { visibleImage: "mask" };
+
     this.resizeKeepAspect = this.resizeKeepAspect.bind(this);
+    this.onImageClick = this.onImageClick.bind(this);
   }
 
   /* Canvas-based code may eventually be useful when loading
@@ -43,6 +50,18 @@ class LetterImage extends React.Component {
     }
   }
 
+  onImageClick() {
+    if (this.state.visibleImage == "mask") {
+      this.refs.mask.className = "hidden";
+      this.refs.context.className = "";
+      this.setState({ visibleImage: "context"})
+    } else {
+      this.refs.mask.className = "";
+      this.refs.context.className = "hidden";
+      this.setState({ visibleImage: "mask"})
+    }
+  }
+
   render() {
     let imgWidth = this.props.coords.width;
     let imgHeight = this.props.coords.height;
@@ -60,13 +79,38 @@ class LetterImage extends React.Component {
       dims = this.resizeKeepAspect(imgWidth, imgHeight, maxDim);
     }
 
+    let margin = MEDIUM_MARGIN;
+
+    let leftExpanded = Math.max(0, this.props.coords.left - margin);
+    let topExpanded = Math.max(0, this.props.coords.top - margin);
+    let rightExpanded = Math.min(this.props.coords.pagewidth, 
+                                 this.props.coords.left + this.props.coords.width + margin);
+    let widthExpanded = rightExpanded - leftExpanded;
+    let bottomExpanded = Math.min(this.props.coords.pageheight,
+                                  this.props.coords.top + this.props.coords.height + margin);
+    let heightExpanded = bottomExpanded - topExpanded;
+
+    let cropURL =
+    "http://127.0.0.1:8000/api/crop?page_url=" +
+    this.props.coords.pageurl +
+    "&x=" +
+    leftExpanded +
+    "&y=" +
+    topExpanded +
+    "&w=" +
+    widthExpanded +
+    "&h=" +
+    heightExpanded;
+
     return (
-      <span style={{ display: "inline-block" }}>
-        {/*<canvas ref="canvas" width={maxDim} height={maxDim}  />
-        <img ref="image" src={this.props.coords.binaryurl} className="hidden" />*/}
+      <span style={{ margin: "5px", display: "inline-block" }}
+            onClick={this.onImageClick}
+      >
+        {/*{<canvas ref="canvas" width={maxDim} height={maxDim} className="hidden"   />*/}
+        <img alt={this.props.letter} ref="context" src={cropURL} className="hidden" />
         <img
           alt={this.props.letter}
-          //ref="image"
+          ref="mask"
           width={dims.width}
           height={dims.height}
           src={this.props.coords.binaryurl}

--- a/js/components/LetterImage.js
+++ b/js/components/LetterImage.js
@@ -1,5 +1,7 @@
 import React from "react";
 
+import { API_ROOT } from "./App";
+
 /* LetterImage - displays a letter image retrieved from
  * a URL that points to the image on the backend server.
  * It also resizes the image according to the size specified
@@ -54,11 +56,11 @@ class LetterImage extends React.Component {
     if (this.state.visibleImage == "mask") {
       this.refs.mask.className = "hidden";
       this.refs.context.className = "";
-      this.setState({ visibleImage: "context"})
+      this.setState({ visibleImage: "context" });
     } else {
       this.refs.mask.className = "";
       this.refs.context.className = "hidden";
-      this.setState({ visibleImage: "mask"})
+      this.setState({ visibleImage: "mask" });
     }
   }
 
@@ -83,31 +85,42 @@ class LetterImage extends React.Component {
 
     let leftExpanded = Math.max(0, this.props.coords.left - margin);
     let topExpanded = Math.max(0, this.props.coords.top - margin);
-    let rightExpanded = Math.min(this.props.coords.pagewidth, 
-                                 this.props.coords.left + this.props.coords.width + margin);
+    let rightExpanded = Math.min(
+      this.props.coords.pagewidth,
+      this.props.coords.left + this.props.coords.width + margin
+    );
     let widthExpanded = rightExpanded - leftExpanded;
-    let bottomExpanded = Math.min(this.props.coords.pageheight,
-                                  this.props.coords.top + this.props.coords.height + margin);
+    let bottomExpanded = Math.min(
+      this.props.coords.pageheight,
+      this.props.coords.top + this.props.coords.height + margin
+    );
     let heightExpanded = bottomExpanded - topExpanded;
 
     let cropURL =
-    "http://127.0.0.1:8000/api/crop?page_url=" +
-    this.props.coords.pageurl +
-    "&x=" +
-    leftExpanded +
-    "&y=" +
-    topExpanded +
-    "&w=" +
-    widthExpanded +
-    "&h=" +
-    heightExpanded;
+      API_ROOT +
+      "crop?page_url=" +
+      this.props.coords.pageurl +
+      "&x=" +
+      leftExpanded +
+      "&y=" +
+      topExpanded +
+      "&w=" +
+      widthExpanded +
+      "&h=" +
+      heightExpanded;
 
     return (
-      <span style={{ margin: "5px", display: "inline-block" }}
-            onClick={this.onImageClick}
+      <span
+        style={{ margin: "5px", display: "inline-block" }}
+        onClick={this.onImageClick}
       >
         {/*{<canvas ref="canvas" width={maxDim} height={maxDim} className="hidden"   />*/}
-        <img alt={this.props.letter} ref="context" src={cropURL} className="hidden" />
+        <img
+          alt={this.props.letter}
+          ref="context"
+          src={cropURL}
+          className="hidden"
+        />
         <img
           alt={this.props.letter}
           ref="mask"


### PR DESCRIPTION
The letter image component now queries the new manuscript image crop/ API endpoint to load a manuscript excerpt given the dimensions of the binarized letter and a variable-sized margin around it (which will eventually be set by the user via the form). The cropped manuscript image loads "behind" the binarized letter; visibility of one or the other is toggled by clicking on the images.