### PR TITLE
Update scriptchart table styles

### DIFF
--- a/js/components/ScriptChart.css
+++ b/js/components/ScriptChart.css
@@ -1,6 +1,8 @@
-table, th, td {
-  color: black;
-  border: 1px solid gray;
+table th {
+  background-color: #f0f0f0;
+  border: 1px solid #dedede;
+  border-bottom-color: rgb(222, 222, 222);
+  border-bottom-color: #c9c9c9;
 }
 
 td img {
@@ -17,6 +19,7 @@ th {
 td {
   padding: 5px;
   text-align: left;
+  border: 1px solid #e8e8e8;
 }
 
 td:hover {


### PR DESCRIPTION
Updated CSS styles for the scriptchart table, re-applying some styles that had previously been inherited from Mirador or Minima but went away after the CSS refactor in https://github.com/sul-cidr/scriptchart/pull/36.