### PR TITLE
Reduce probability of rare race condition with yarn dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "build": "node_modules/.bin/webpack -p && bundle exec jekyll clean && bundle exec jekyll build",
-    "dev": "bundle exec jekyll build; yarn concurrently \"bundle exec jekyll serve\" \"node_modules/.bin/webpack --watch\"",
+    "dev": "yarn concurrently \"bundle exec jekyll serve\" \"node_modules/.bin/webpack --watch\"",
     "precommit": "lint-staged",
     "deploy": "gh-pages -d _site",
     "test": "node_modules/.bin/jest",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "build": "node_modules/.bin/webpack -p && bundle exec jekyll clean && bundle exec jekyll build",
-    "dev": "yarn concurrently \"node_modules/.bin/webpack --watch\" \"bundle exec jekyll serve\"",
+    "dev": "bundle exec jekyll build; yarn concurrently \"bundle exec jekyll serve\" \"node_modules/.bin/webpack --watch\"",
     "precommit": "lint-staged",
     "deploy": "gh-pages -d _site",
     "test": "node_modules/.bin/jest",


### PR DESCRIPTION
Running `jekyll serve` before `webpack --watch` under `yarn concurrently` should make it very unlikely that webpack will run first and not be able to find the `_site` folder the first time that `yarn dev` is run on a clean install. There's perhaps a slight chance this can still happen, but the fix to make it completely impossible is rather heavyweight and seems excessive given that these commands will only ever be run in a development environment.