### PR TITLE
New form multi-select options, partial CSS consolidation

### DIFF
--- a/js/components/ChartAccordion.js
+++ b/js/components/ChartAccordion.js
@@ -2,7 +2,7 @@ import React from "react";
 
 /* ChartAccordion - This collapsible accordion menu, built on
  * react-acessible-accordion, lives under the "Hidden Items"
- * tab. It display manuscript and letter items for the columns
+ * tab. It displays manuscript and letter items for the columns
  * and rows that have been hidden on the scriptchart, and
  * signals the scriptchart to redisplay them when they are
  * selected.
@@ -23,7 +23,6 @@ import {
   AccordionItemBody
 } from "react-accessible-accordion";
 
-// XXX Should this file be somewhere else? It's needed to style the accordion.
 import "../../node_modules/react-accessible-accordion/dist/fancy-example.css";
 
 class ChartAccordion extends React.Component {
@@ -70,6 +69,7 @@ class ChartAccordion extends React.Component {
                   <LetterButton
                     key={ltid}
                     letterID={ltid}
+                    buttonClass="button is-outlined"
                     onHiddenChange={this.props.onHiddenChange}
                     letter={<SyriacLetter id={ltid} />}
                   />

--- a/js/components/DashTabs.js
+++ b/js/components/DashTabs.js
@@ -4,17 +4,17 @@ import React from "react";
  * scriptchart table and accompanying Mirador viewer
  * and ChartAccordion list of hidden manuscripts and letters
  * reside under their own tabs.
- * 
+ *
  * It is responsible for keeping track of the contents and
  * orderings of the rows and columns in the table, as well
  * as those that have been hidden and are listed in the
  * ChartAccordion. As such, it handles dragging and dropping
  * of rows and columns, as well as hiding/redisplaying them.
- * 
- * Conditional rendering: this component is blank until the
- * configuration form is submitted, at which time it populates
- * the letter and manuscript lists with data that the App
- * has queried from the REST API.
+ *
+ * Conditional rendering: this component displays a text prompt
+ * until the configuration form is submitted, at which time it
+ * populates the letter and manuscript lists with data that the
+ * App has queried from the REST API.
  */
 
 import ScriptChart from "./ScriptChart";
@@ -26,7 +26,7 @@ import "react-tabs/style/react-tabs.css";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
-import "./DashTabs.css";
+import "./index.css";
 
 class DashTabs extends React.Component {
   constructor(props) {
@@ -70,7 +70,7 @@ class DashTabs extends React.Component {
      * 'pre-manuscript' columns (which contain the row
      * letter labels and the Xs used to hide rows).
      */
-    if ((sourceIndex < 0) || (targetIndex < 0)) {
+    if (sourceIndex < 0 || targetIndex < 0) {
       return;
     }
 
@@ -161,7 +161,13 @@ class DashTabs extends React.Component {
 
   render() {
     if (this.props.showTabs == false) {
-      return <div />;
+      return (
+        <div>
+          <span>
+            <strong>{this.props.loadingMessage}</strong>
+          </span>
+        </div>
+      );
     }
 
     console.log("Rendering DashTabs");

--- a/js/components/DragTable.js
+++ b/js/components/DragTable.js
@@ -59,7 +59,7 @@ class DragTable extends React.Component {
           onRow={this.props.onRow}
           style={{
             maxWidth: "100vw",
-            maxHeight: "100vh"
+            maxHeight: "100%"
           }}
           ref={tableBody => {
             this.tableBody = tableBody && tableBody.getRef();

--- a/js/components/LetterButton.js
+++ b/js/components/LetterButton.js
@@ -13,25 +13,22 @@ import React from "react";
 class LetterButton extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { buttonClass: "button is-outlined" };
     this.onLetterClicked = this.onLetterClicked.bind(this);
   }
   onLetterClicked() {
     if (this.props.hasOwnProperty("onHiddenChange")) {
       this.props.onHiddenChange("show", "row", this.props.letterID);
     } else {
-      if (this.state.buttonClass === "button is-outlined") {
-        this.setState({ buttonClass: "button is-success" });
+      if (this.props.buttonClass === "button is-outlined") {
         this.props.onLetterClick(this.props.letterID, "select");
       } else {
-        this.setState({ buttonClass: "button is-outlined" });
         this.props.onLetterClick(this.props.letterID, "deselect");
       }
     }
   }
   render() {
     return (
-      <span className={this.state.buttonClass} onClick={this.onLetterClicked}>
+      <span className={this.props.buttonClass} onClick={this.onLetterClicked}>
         {this.props.letter}
       </span>
     );

--- a/js/components/LettersLoader.js
+++ b/js/components/LettersLoader.js
@@ -3,10 +3,9 @@ import React from "react";
 /* LettersLoader - Builds a grid of LetterButtons (containing
  * SyriacLetter components) for the configuration form.
  * It doesn't actually "load" the letters from a remote location
- * -- rather, they're now read from an array in the SyriacLetter
- * component.
- * It also updates the form's list of selected letters when one
- * is selected/deselected.
+ * -- rather, they're now read from an array in letters.json.
+ * It also passes letter button select/deselect events up to
+ * the form component.
  */
 
 import LetterButton from "./LetterButton";
@@ -18,58 +17,33 @@ import letters from "./letters.json";
 class LettersLoader extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { letterButtons: [], selectedLetters: [] };
+
     this.buttonClick = this.buttonClick.bind(this);
   }
 
-  buttonClick(letterID, operation) {
-    let selectedLetters = [...this.state.selectedLetters];
-    if (operation == "select") {
-      /* The list of selected letters should be in "aphabetical" order */
-      let newLetter = letters.find(lt => lt.id == letterID);
-      selectedLetters.push(newLetter);
-      let alphabetizedSelection = letters.reduce((result, lt) => {
-        if (selectedLetters.findIndex(l => l.id == lt.id) >= 0) {
-          result.push(lt)
-        }
-        return result;
-      }, []);
-      selectedLetters = alphabetizedSelection;
-    } else {
-      selectedLetters.splice(
-        selectedLetters.findIndex(lt => lt.id == letterID),
-        1
-      );
-    }
-    this.props.handleSelect("letters", selectedLetters);
-    this.setState({ selectedLetters });
+  buttonClick(letterID, action) {
+    this.props.handleSelect(letterID, action);
   }
 
-  /* For convenience, use the Syriac letters defined in SyriacLetter.js, rather
-   * than those avaialble via the API. The letter set is extremely unlikely to
-   * change (unlike the manuscripts/pages/coords), so loading it dynamically
-   * doesn't seem worth the hassle. Care must of course be taken that the
-   * static letters list remains in sync with the DB, particulary regarding IDs.
-   */
-  componentDidMount() {
+  render() {
+    console.log("Rendering letters loader");
+
     let buttons = letters.map(lt => {
+      let letterClass = "button is-outlined";
+      if (this.props.selectedLetters.findIndex(l => l.id == lt.id) >= 0) {
+        letterClass = "button is-success";
+      }
       return (
         <LetterButton
           key={lt.id}
           letterID={lt.id}
           onLetterClick={this.buttonClick}
+          buttonClass={letterClass}
           letter={<SyriacLetter id={lt.id} />}
         />
       );
     });
-
-    this.setState({ letterButtons: buttons });
-  }
-
-  render() {
-    return (
-      <div className={"buttons are-small"}>{this.state.letterButtons}</div>
-    );
+    return <div className={"buttons are-small"}>{buttons}</div>;
   }
 }
 

--- a/js/components/ManuscriptForm.js
+++ b/js/components/ManuscriptForm.js
@@ -1,7 +1,7 @@
 import React from "react";
 
 /* ManuscriptForm - The top-level component of the manuscript/letters
- * selection form (aka the scriptchart configuration form).
+ * selection form (aka the scriptchart options form).
  * Changes made to any of the form options eventually make their way
  * back to this component's state.
  * Its state is sent back to the App as the form data, to be
@@ -12,14 +12,18 @@ import React from "react";
 import ManuscriptMenu from "./ManuscriptMenu";
 import LettersLoader from "./LettersLoader";
 
+import letters from "./letters.json";
+
 class ManuscriptForm extends React.Component {
   constructor(props) {
     super(props);
 
-    /* The form defaults are largely set here */
+    /* Most of the form defaults are set here */
     this.state = {
       showBinarized: true,
       letterExamples: 3,
+      cropMargin: "Medium",
+      imageDisplay: "hover",
       imageSize: "Small",
       selectedShelfmarks: [],
       manuscripts: [],
@@ -29,6 +33,71 @@ class ManuscriptForm extends React.Component {
     this.handleChange = this.handleChange.bind(this);
     this.handleSelect = this.handleSelect.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
+    this.buttonChange = this.buttonChange.bind(this);
+    this.lettersSelect = this.lettersSelect.bind(this);
+    this.changeCropMargin = this.changeCropMargin.bind(this);
+    this.changeImageDisplay = this.changeImageDisplay.bind(this);
+  }
+
+  changeImageDisplay(event) {
+    const imageDisplay = event.target.value;
+
+    this.setState({ imageDisplay });
+  }
+
+  changeCropMargin(event) {
+    const cropMargin = event.target.value;
+
+    this.setState({ cropMargin });
+  }
+
+  buttonChange(letterID, operation) {
+    let selectedLetters = [...this.state.letters];
+    if (operation == "select") {
+      /* The list of selected letters should be in "aphabetical" order */
+      let newLetter = letters.find(lt => lt.id == letterID);
+      selectedLetters.push(newLetter);
+      let alphabetizedSelection = letters.reduce((result, lt) => {
+        if (selectedLetters.findIndex(l => l.id == lt.id) >= 0) {
+          result.push(lt);
+        }
+        return result;
+      }, []);
+      selectedLetters = alphabetizedSelection;
+    } else {
+      selectedLetters.splice(
+        selectedLetters.findIndex(lt => lt.id == letterID),
+        1
+      );
+    }
+    this.handleSelect("letters", selectedLetters);
+  }
+
+  lettersSelect(event) {
+    const which = event.target.textContent;
+    let selectedLetters = [];
+    if (which != "Select none") {
+      selectedLetters = [...this.state.letters];
+      for (let lt of letters) {
+        let ltid = lt.id;
+        if (
+          which == "Select all" &&
+          selectedLetters.findIndex(l => l.id == ltid) < 0
+        ) {
+          selectedLetters.push(lt);
+        } else if (which == "Invert selection") {
+          if (selectedLetters.findIndex(l => l.id == ltid) < 0) {
+            selectedLetters.push(lt);
+          } else {
+            selectedLetters.splice(
+              selectedLetters.findIndex(l => l.id == ltid),
+              1
+            );
+          }
+        }
+      }
+    }
+    this.handleSelect("letters", selectedLetters);
   }
 
   handleChange(event) {
@@ -52,9 +121,9 @@ class ManuscriptForm extends React.Component {
   }
 
   handleSubmit(event) {
-    // Stop the whole darn page from reloading on submit
+    // Stop the whole darn page from reloading on form submit
     event.preventDefault();
-    // Pass all of the form's state to the handler (which is in DashTabs)
+    // Pass all of the form's state to the handler (which is in App)
     this.props.formSubmit(this.state);
   }
 
@@ -66,53 +135,135 @@ class ManuscriptForm extends React.Component {
           handleChange={this.handleChange}
           handleSelect={this.handleSelect}
           manuscripts={this.props.manuscripts}
+          selectedShelfmarks={this.state.selectedShelfmarks}
+          sortManuscripts={this.props.sortManuscripts}
         />
         <div className={"field"}>
-          <label className={"control"}>Select Letters:</label>
-          <LettersLoader handleSelect={this.handleSelect} />
+          <label className={"control"}>Select letters:</label>
+          <div className={"control"} style={{ marginBottom: 5 }}>
+            <span className="button is-small" onClick={this.lettersSelect}>
+              Select all
+            </span>
+            <span className="button is-small" onClick={this.lettersSelect}>
+              Select none
+            </span>
+            <span className="button is-small" onClick={this.lettersSelect}>
+              Invert selection
+            </span>
+          </div>
+          <LettersLoader
+            selectedLetters={this.state.letters}
+            handleSelect={this.buttonChange}
+          />
         </div>
-        <div className={"field"}>
-          <label className={"control"}>Select number of letter examples:</label>
-          <div className={"control"}>
-            <div className={"select"}>
-              <select
-                value={this.state.letterExamples}
-                type="number"
-                name="letterExamples"
-                onChange={this.handleChange}
-              >
-                <option>1</option>
-                <option>3</option>
-                <option>5</option>
-              </select>
+        <div className={"field is-horizontal"}>
+          <div className={"field-label is-normal"}>
+            <div style={{ whiteSpace: "nowrap" }}>
+              Number of letter examples:
+            </div>
+          </div>
+          <div className={"field-body"}>
+            <div className={"field is-narrow"}>
+              <div className={"control"}>
+                <div className={"select is-small is-fullwidth"}>
+                  <select
+                    value={this.state.letterExamples}
+                    type="number"
+                    name="letterExamples"
+                    onChange={this.handleChange}
+                  >
+                    <option>1</option>
+                    <option>3</option>
+                    <option>5</option>
+                  </select>
+                </div>
+              </div>
             </div>
           </div>
         </div>
-        <div className={"field"}>
-          <label className={"checkbox"}>
-            Show binarized images?
-            <input
-              onChange={this.handleChange}
-              type="checkbox"
-              name="showBinarized"
-              checked={this.state.showBinarized}
-            />
-          </label>
+        <div className={"field is-horizontal"}>
+          <div className={"field-label is-normal"}>
+            <div style={{ whiteSpace: "nowrap" }}>Select image size:</div>
+          </div>
+          <div className={"field-body"}>
+            <div className={"field is-narrow"}>
+              <div className={"control"}>
+                <div className={"select is-small is-fullwidth"}>
+                  <select
+                    value={this.state.imageSize}
+                    type="string"
+                    name="imageSize"
+                    onChange={this.handleChange}
+                    disabled={this.state.imageDisplay == "cropped"}
+                  >
+                    <option>Small</option>
+                    <option>Medium</option>
+                    <option>Large</option>
+                  </select>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
-        <div className={"field"}>
-          <label className={"control"}>Select image size:</label>
-          <div className={"control"}>
-            <div className={"select"}>
-              <select
-                value={this.state.imageSize}
-                type="string"
-                name="imageSize"
-                onChange={this.handleChange}
-              >
-                <option>Small</option>
-                <option>Medium</option>
-                <option>Large</option>
-              </select>
+        <div className={"control"}>
+          <p>Letter image options:</p>
+          <ul>
+            <li>
+              <label className={"radio"}>
+                <input
+                  type="radio"
+                  value="binarized"
+                  onChange={this.changeImageDisplay}
+                  checked={this.state.imageDisplay == "binarized"}
+                />{" "}
+                Show binarized only
+              </label>
+            </li>
+            <li>
+              <label className={"radio"}>
+                <input
+                  type="radio"
+                  value="hover"
+                  onChange={this.changeImageDisplay}
+                  checked={this.state.imageDisplay == "hover"}
+                />{" "}
+                Show cropped images on hover
+              </label>
+            </li>
+            <li>
+              <label className={"radio"}>
+                <input
+                  type="radio"
+                  value="cropped"
+                  onChange={this.changeImageDisplay}
+                  checked={this.state.imageDisplay == "cropped"}
+                />{" "}
+                Show cropped images only
+              </label>
+            </li>
+          </ul>
+        </div>
+        <div className={"field is-horizontal"}>
+          <div className={"field-label is-normal"}>
+            <div style={{ whiteSpace: "nowrap" }}>Cropped margin size:</div>
+          </div>
+          <div className={"field-body"}>
+            <div className={"field is-narrow"}>
+              <div className={"control"}>
+                <div className={"select is-small is-fullwidth"}>
+                  <select
+                    value={this.state.cropMargin}
+                    type="string"
+                    name="cropMargin"
+                    onChange={this.changeCropMargin}
+                    disabled={this.state.imageDisplay == "binarized"}
+                  >
+                    <option>None</option>
+                    <option>Medium</option>
+                    <option>Large</option>
+                  </select>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/js/components/ManuscriptMenu.js
+++ b/js/components/ManuscriptMenu.js
@@ -2,34 +2,114 @@ import React from "react";
 
 /* ManuscriptMenu - A sub-component of the ManuscriptForm; provides
  * a multi-select list of the available manuscripts (encased in
- * the ManuscriptsLoader component) and options for sorting the
- * list.
+ * the ManuscriptsLoader component) and options for sorting and
+ * multi-selecting the list elements.
  */
 
 import ManuscriptsLoader from "./ManuscriptsLoader";
 
 class ManuscriptMenu extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = { orderByShelfmark: true };
+
+    this.changeSort = this.changeSort.bind(this);
+    this.manuscriptsSelect = this.manuscriptsSelect.bind(this);
+    this.handleSelect = this.handleSelect.bind(this);
+  }
+
+  handleSelect(event) {
+    let options = event.target.options;
+    let name = event.target.name;
+    let value = [];
+    let selectedShelfmarks = [];
+    for (let i = 0, l = options.length; i < l; i++) {
+      if (options[i].selected) {
+        value.push(options[i].value);
+        selectedShelfmarks.push(options[i].value);
+      }
+    }
+
+    this.props.handleSelect(name, value);
+  }
+
+  manuscriptsSelect(event) {
+    const which = event.target.textContent;
+    let selectedShelfmarks = [];
+    if (which != "Select none") {
+      selectedShelfmarks = JSON.parse(
+        JSON.stringify(this.props.selectedShelfmarks)
+      );
+      for (let ms of this.props.manuscripts) {
+        let sm = ms.shelfmark;
+        if (which == "Select all" && selectedShelfmarks.indexOf(sm) < 0) {
+          selectedShelfmarks.push(sm);
+        } else if (which == "Invert selection") {
+          if (selectedShelfmarks.indexOf(sm) < 0) {
+            selectedShelfmarks.push(sm);
+          } else {
+            selectedShelfmarks.splice(selectedShelfmarks.indexOf(sm), 1);
+          }
+        }
+      }
+    }
+    this.props.handleSelect("selectedShelfmarks", selectedShelfmarks);
+  }
+
+  changeSort(event) {
+    const value = event.target.value;
+
+    if (value == "shelfmark") {
+      this.setState({ orderByShelfmark: true });
+    } else {
+      // value == "date"
+      this.setState({ orderByShelfmark: false });
+    }
+    this.props.sortManuscripts(value);
+  }
+
   render() {
     return (
       <div className={"field"}>
-        <label className={"control"}>Select Manuscripts:</label>
-        <div className={"control"}>
-          <div className={"select is-multiple"}>
-            <ManuscriptsLoader
-              handleSelect={this.props.handleSelect}
-              manuscripts={this.props.manuscripts}
-            />
-          </div>
+        <label className={"control"}>Select manuscripts:</label>
+        <div className={"control"} style={{ marginBottom: 5 }}>
+          <span className="button is-small" onClick={this.manuscriptsSelect}>
+            Select all
+          </span>
+          <span className="button is-small" onClick={this.manuscriptsSelect}>
+            Select none
+          </span>
+          <span className="button is-small" onClick={this.manuscriptsSelect}>
+            Invert selection
+          </span>
         </div>
-        <div className={"control sort-option"}>
-          <p>Order manuscripts by:</p>
+        <div className={"select is-multiple"}>
+          <ManuscriptsLoader
+            handleSelect={this.handleSelect}
+            manuscripts={this.props.manuscripts}
+            selectedShelfmarks={this.props.selectedShelfmarks}
+          />
+        </div>
+        <div className={"control"}>
+          <p>Order manuscripts by</p>
           <label className={"radio"}>
-            Shelfmark:
-            <input type={"radio"} name={"Shelfmark"} defaultChecked />
+            <input
+              type="radio"
+              value="shelfmark"
+              onChange={this.changeSort}
+              checked={this.state.orderByShelfmark}
+            />{" "}
+            Shelfmark |
           </label>
           <label className={"radio"}>
-            Date:
-            <input type={"radio"} name={"Date"} />
+            <input
+              type="radio"
+              value="date"
+              onChange={this.changeSort}
+              checked={!this.state.orderByShelfmark}
+            />{" "}
+            Date
           </label>
         </div>
       </div>

--- a/js/components/ManuscriptsLoader.js
+++ b/js/components/ManuscriptsLoader.js
@@ -8,44 +8,26 @@ import React from "react";
  */
 
 class ManuscriptsLoader extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = { selectedShelfmarks: [] };
-
-    this.handleSelect = this.handleSelect.bind(this);
-  }
-
-  handleSelect(event) {
-    let options = event.target.options;
-    let name = event.target.name;
-    let value = [];
-    let selectedShelfmarks = [];
-    for (let i = 0, l = options.length; i < l; i++) {
-      if (options[i].selected) {
-        value.push(options[i].value);
-        selectedShelfmarks.push(options[i].value);
-      }
-    }
-    this.setState({ selectedShelfmarks });
-
-    this.props.handleSelect(name, value);
-  }
 
   render() {
-    let manuscriptSelectors = this.props.manuscripts.map(ms => {
-      return (
-        <option key={ms.id} value={ms.shelfmark}>
-          {ms.shelfmark}
-        </option>
-      );
-    });
+    let manuscriptSelectors = <option>Finding manuscripts...</option>;
 
+    if ((this.props.manuscripts !== null) && (this.props.manuscripts.length > 0)) {
+      manuscriptSelectors = this.props.manuscripts.map(ms => {
+        return (
+          <option key={ms.id} value={ms.shelfmark}>
+            {ms.shelfmark} ({ms.date ? ms.date : 'NA'})
+          </option>
+        );
+      });
+    }
+    
     return (
-      <select
+      <select multiple size="8"
         type="string"
         name="selectedShelfmarks"
-        value={this.state.selectedShelfmarks}
-        onChange={this.handleSelect}
+        value={this.props.selectedShelfmarks}
+        onChange={this.props.handleSelect}
         multiple={true}
       >
         {manuscriptSelectors}

--- a/js/components/__mocks__/appDataMock.js
+++ b/js/components/__mocks__/appDataMock.js
@@ -1,178 +1,206 @@
-export const defaultManuscripts = [
+export const formData = {
+  showBinarized: true,
+  letterExamples: 3,
+  imageSize: "Small",
+  selectedShelfmarks: ["Vat. Syr. 112", "Vat. Syr. 140", "BL. Add. 17224"],
+  manuscripts: [],
+  letters: [
     {
-      id: 3,
-      shelfmark: "Vat. Syr. 092",
-      source: null,
-      page: null,
-      folio: null,
-      scribe: null,
-      date: "823",
-      resolution: "Color",
-      notes: null,
-      manifest: "https://digi.vatlib.it/iiif/MSS_Vat.sir.92/manifest.json",
-      display: true
-    },
-    {
-      id: 9,
-      shelfmark: "Vat. Syr. 112",
-      source: null,
-      page: null,
-      folio: null,
-      scribe: null,
-      date: "552",
-      resolution: null,
-      notes: null,
-      manifest: "https://digi.vatlib.it/iiif/MSS_Vat.sir.112/manifest.json",
-      display: true
-    },
-    {
-      id: 11,
-      shelfmark: "Vat. Syr. 140",
-      source: null,
-      page: null,
-      folio: null,
-      scribe: null,
-      date: "528",
-      resolution: "Black and White",
-      notes: null,
-      manifest: "https://digi.vatlib.it/iiif/MSS_Vat.sir.140/manifest.json",
-      display: true
-    },
-    {
-      id: 16,
-      shelfmark: "BL. Add. 17224",
-      source: null,
-      page: null,
-      folio: null,
-      scribe: "--",
-      date: "1173",
-      resolution: "Black and White",
-      notes: null,
-      manifest: null,
-      display: true
-    },
-    {
-      id: 17,
-      shelfmark: "BL. Add. 12144",
-      source: null,
-      page: null,
-      folio: null,
-      scribe: "Samuel b. Cyriacus",
-      date: "1081",
-      resolution: "Black and White",
-      notes: null,
-      manifest: null,
-      display: true
-    },
-    {
-      id: 18,
-      shelfmark: "BL. Add. 12134",
-      source: null,
-      page: null,
-      folio: null,
-      scribe: null,
-      date: "697",
-      resolution: "Black and white",
-      notes: null,
-      manifest: null,
-      display: true
-    },
-    {
-      id: 19,
-      shelfmark: "BL. Add. 14445",
-      source: null,
-      page: null,
-      folio: null,
-      scribe: null,
-      date: "532",
-      resolution: "Black and White",
-      notes: null,
-      manifest: null,
-      display: true
-    },
-    {
-      id: 20,
-      shelfmark: "BL. Add. 12146",
-      source: null,
-      page: null,
-      folio: null,
-      scribe: "Yesua b. Hannan",
-      date: "1007",
-      resolution: "Color",
-      notes: null,
-      manifest: null,
-      display: true
-    },
-    {
-      id: 21,
-      shelfmark: "BL. Or. 8732",
-      source: null,
-      page: null,
-      folio: null,
-      scribe: "--",
-      date: "770",
-      resolution: "Black and White",
-      notes: "Script - Estrangela",
-      manifest: null,
-      display: true
-    },
-    {
-      id: 22,
-      shelfmark: "BL. Or. 8606",
-      source: null,
-      page: null,
-      folio: null,
-      scribe: "--",
-      date: "723",
-      resolution: "Black and White",
-      notes: null,
-      manifest: null,
-      display: true
-    },
-    {
-      id: 23,
-      shelfmark: "BL. Add. 17102",
-      source: null,
-      page: null,
-      folio: null,
-      scribe: "--",
-      date: "598-599",
-      resolution: "Black and White",
-      notes: "Script - Estrangela",
-      manifest: null,
-      display: true
-    },
-    {
-      id: 24,
-      shelfmark: "BL. Add. 17107",
-      source: null,
-      page: null,
-      folio: null,
-      scribe: "--",
-      date: "540-541",
-      resolution: "Black and White",
-      notes: "Script - Estrangela",
-      manifest: null,
-      display: true
+      id: 2,
+      letter: "Alaph (Angular)",
+      is_script: true,
+      display: "ܐ",
+      script: "estrangela"
     },
     {
       id: 25,
-      shelfmark: "BL. Add. 12175",
-      source: null,
-      page: null,
-      folio: null,
-      scribe: null,
-      date: "533-534",
-      resolution: "Black and White",
-      notes: null,
-      manifest: null,
-      display: true
+      letter: "Lamadh (Final, open)",
+      is_script: true,
+      display: "ܠ",
+      script: "estrangela"
+    },
+    {
+      id: 37,
+      letter: "Sadhe",
+      is_script: true,
+      display: "ܨ",
+      script: "estrangela"
     }
-  ];
-  
+  ]
+};
+
+export const defaultManuscripts = [
+  {
+    id: 3,
+    shelfmark: "Vat. Syr. 092",
+    source: null,
+    page: null,
+    folio: null,
+    scribe: null,
+    date: "823",
+    resolution: "Color",
+    notes: null,
+    manifest: "https://digi.vatlib.it/iiif/MSS_Vat.sir.92/manifest.json",
+    display: true
+  },
+  {
+    id: 9,
+    shelfmark: "Vat. Syr. 112",
+    source: null,
+    page: null,
+    folio: null,
+    scribe: null,
+    date: "552",
+    resolution: null,
+    notes: null,
+    manifest: "https://digi.vatlib.it/iiif/MSS_Vat.sir.112/manifest.json",
+    display: true
+  },
+  {
+    id: 11,
+    shelfmark: "Vat. Syr. 140",
+    source: null,
+    page: null,
+    folio: null,
+    scribe: null,
+    date: "528",
+    resolution: "Black and White",
+    notes: null,
+    manifest: "https://digi.vatlib.it/iiif/MSS_Vat.sir.140/manifest.json",
+    display: true
+  },
+  {
+    id: 16,
+    shelfmark: "BL. Add. 17224",
+    source: null,
+    page: null,
+    folio: null,
+    scribe: "--",
+    date: "1173",
+    resolution: "Black and White",
+    notes: null,
+    manifest: null,
+    display: true
+  },
+  {
+    id: 17,
+    shelfmark: "BL. Add. 12144",
+    source: null,
+    page: null,
+    folio: null,
+    scribe: "Samuel b. Cyriacus",
+    date: "1081",
+    resolution: "Black and White",
+    notes: null,
+    manifest: null,
+    display: true
+  },
+  {
+    id: 18,
+    shelfmark: "BL. Add. 12134",
+    source: null,
+    page: null,
+    folio: null,
+    scribe: null,
+    date: "697",
+    resolution: "Black and white",
+    notes: null,
+    manifest: null,
+    display: true
+  },
+  {
+    id: 19,
+    shelfmark: "BL. Add. 14445",
+    source: null,
+    page: null,
+    folio: null,
+    scribe: null,
+    date: "532",
+    resolution: "Black and White",
+    notes: null,
+    manifest: null,
+    display: true
+  },
+  {
+    id: 20,
+    shelfmark: "BL. Add. 12146",
+    source: null,
+    page: null,
+    folio: null,
+    scribe: "Yesua b. Hannan",
+    date: "1007",
+    resolution: "Color",
+    notes: null,
+    manifest: null,
+    display: true
+  },
+  {
+    id: 21,
+    shelfmark: "BL. Or. 8732",
+    source: null,
+    page: null,
+    folio: null,
+    scribe: "--",
+    date: "770",
+    resolution: "Black and White",
+    notes: "Script - Estrangela",
+    manifest: null,
+    display: true
+  },
+  {
+    id: 22,
+    shelfmark: "BL. Or. 8606",
+    source: null,
+    page: null,
+    folio: null,
+    scribe: "--",
+    date: "723",
+    resolution: "Black and White",
+    notes: null,
+    manifest: null,
+    display: true
+  },
+  {
+    id: 23,
+    shelfmark: "BL. Add. 17102",
+    source: null,
+    page: null,
+    folio: null,
+    scribe: "--",
+    date: "598-599",
+    resolution: "Black and White",
+    notes: "Script - Estrangela",
+    manifest: null,
+    display: true
+  },
+  {
+    id: 24,
+    shelfmark: "BL. Add. 17107",
+    source: null,
+    page: null,
+    folio: null,
+    scribe: "--",
+    date: "540-541",
+    resolution: "Black and White",
+    notes: "Script - Estrangela",
+    manifest: null,
+    display: true
+  },
+  {
+    id: 25,
+    shelfmark: "BL. Add. 12175",
+    source: null,
+    page: null,
+    folio: null,
+    scribe: null,
+    date: "533-534",
+    resolution: "Black and White",
+    notes: null,
+    manifest: null,
+    display: true
+  }
+];
 
 export const tableData = {"9":{"2":[{"page":49,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/Vat.%20Syriac%20112,%20Ephrem,%20Hymns%20on%20Paradise%20(551_%2093%20fols.)/MSS_Vat.sir.112-22b.jpg","letter":2,"binaryurl":"https://images.syriac.reclaim.hosting/binary/Vat. Syr. 112_22b_Alaph (Angular)_611_277_75_50.png","id":44407,"top":277,"left":611,"width":75,"height":50},{"page":613,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/Vat.%20Syriac%20112,%20Ephrem,%20Hymns%20on%20Paradise%20(551_%2093%20fols.)/MSS_Vat.sir.112-31a.jpg","letter":2,"binaryurl":"https://images.syriac.reclaim.hosting/binary/Vat. Syr. 112_31a_Alaph (Angular)_557_289_70_48.png","id":44412,"top":289,"left":557,"width":70,"height":48},{"page":1481,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/Vat.%20Syriac%20112,%20Ephrem,%20Hymns%20on%20Paradise%20(551_%2093%20fols.)/MSS_Vat.sir.112-28a.jpg","letter":2,"binaryurl":"https://images.syriac.reclaim.hosting/binary/Vat. Syr. 112_28a_Alaph (Angular)_1016_249_64_44.png","id":44408,"top":249,"left":1016,"width":64,"height":44},{"page":1481,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/Vat.%20Syriac%20112,%20Ephrem,%20Hymns%20on%20Paradise%20(551_%2093%20fols.)/MSS_Vat.sir.112-28a.jpg","letter":2,"binaryurl":"https://images.syriac.reclaim.hosting/binary/Vat. Syr. 112_28a_Alaph (Angular)_727_357_63_44.png","id":44409,"top":357,"left":727,"width":63,"height":44},{"page":2902,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/Vat.%20Syriac%20112,%20Ephrem,%20Hymns%20on%20Paradise%20(551_%2093%20fols.)/MSS_Vat.sir.112-11b.jpg","letter":2,"binaryurl":"https://images.syriac.reclaim.hosting/binary/Vat. Syr. 112_11b_Alaph (Angular)_252_393_55_46.png","id":44402,"top":393,"left":252,"width":55,"height":46}],"19":[{"page":49,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/Vat.%20Syriac%20112,%20Ephrem,%20Hymns%20on%20Paradise%20(551_%2093%20fols.)/MSS_Vat.sir.112-22b.jpg","letter":19,"binaryurl":"https://images.syriac.reclaim.hosting/binary/Vat. Syr. 112_22b_Kaph_304_277_44_39.png","id":44503,"top":277,"left":304,"width":44,"height":39},{"page":49,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/Vat.%20Syriac%20112,%20Ephrem,%20Hymns%20on%20Paradise%20(551_%2093%20fols.)/MSS_Vat.sir.112-22b.jpg","letter":19,"binaryurl":"https://images.syriac.reclaim.hosting/binary/Vat. Syr. 112_22b_Kaph_727_342_41_40.png","id":44504,"top":342,"left":727,"width":41,"height":40},{"page":613,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/Vat.%20Syriac%20112,%20Ephrem,%20Hymns%20on%20Paradise%20(551_%2093%20fols.)/MSS_Vat.sir.112-31a.jpg","letter":19,"binaryurl":"https://images.syriac.reclaim.hosting/binary/Vat. Syr. 112_31a_Kaph_1034_350_43_44.png","id":44507,"top":350,"left":1034,"width":43,"height":44},{"page":613,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/Vat.%20Syriac%20112,%20Ephrem,%20Hymns%20on%20Paradise%20(551_%2093%20fols.)/MSS_Vat.sir.112-31a.jpg","letter":19,"binaryurl":"https://images.syriac.reclaim.hosting/binary/Vat. Syr. 112_31a_Kaph_959_463_42_38.png","id":44508,"top":463,"left":959,"width":42,"height":38},{"page":1156,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/Vat.%20Syriac%20112,%20Ephrem,%20Hymns%20on%20Paradise%20(551_%2093%20fols.)/MSS_Vat.sir.112-13b.jpg","letter":19,"binaryurl":"https://images.syriac.reclaim.hosting/binary/Vat. Syr. 112_13b_Kaph_504_762_42_38.png","id":44501,"top":762,"left":504,"width":42,"height":38}],"37":[{"page":49,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/Vat.%20Syriac%20112,%20Ephrem,%20Hymns%20on%20Paradise%20(551_%2093%20fols.)/MSS_Vat.sir.112-22b.jpg","letter":37,"binaryurl":"https://images.syriac.reclaim.hosting/binary/Vat. Syr. 112_22b_Sadhe_732_1071_106_59.png","id":44593,"top":1071,"left":732,"width":106,"height":59},{"page":49,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/Vat.%20Syriac%20112,%20Ephrem,%20Hymns%20on%20Paradise%20(551_%2093%20fols.)/MSS_Vat.sir.112-22b.jpg","letter":37,"binaryurl":"https://images.syriac.reclaim.hosting/binary/Vat. Syr. 112_22b_Sadhe_465_1427_75_54.png","id":44594,"top":1427,"left":465,"width":75,"height":54},{"page":1156,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/Vat.%20Syriac%20112,%20Ephrem,%20Hymns%20on%20Paradise%20(551_%2093%20fols.)/MSS_Vat.sir.112-13b.jpg","letter":37,"binaryurl":"https://images.syriac.reclaim.hosting/binary/Vat. Syr. 112_13b_Sadhe_582_1301_76_51.png","id":44592,"top":1301,"left":582,"width":76,"height":51},{"page":1377,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/VatSyr112/VatSyr112-006.png","letter":37,"binaryurl":"https://images.syriac.reclaim.hosting/binary/Vat. Syr. 112_3L_Sadhe_735_855_61_46.png","id":9863,"top":855,"left":735,"width":61,"height":46},{"page":1377,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/VatSyr112/VatSyr112-006.png","letter":37,"binaryurl":"https://images.syriac.reclaim.hosting/binary/Vat. Syr. 112_3L_Sadhe_636_1134_62_50.png","id":9864,"top":1134,"left":636,"width":62,"height":50}]},"11":{"2":[{"page":208,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/VatSyr140/VatSyr140-003.png","letter":2,"binaryurl":"https://images.syriac.reclaim.hosting/binary/Vat. Syr. 140_1R_Alaph (Angular)_201_258_23_24.png","id":74759,"top":258,"left":201,"width":23,"height":24},{"page":208,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/VatSyr140/VatSyr140-003.png","letter":2,"binaryurl":"https://images.syriac.reclaim.hosting/binary/Vat. Syr. 140_1R_Alaph (Angular)_278_254_22_24.png","id":74760,"top":254,"left":278,"width":22,"height":24},{"page":208,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/VatSyr140/VatSyr140-003.png","letter":2,"binaryurl":"https://images.syriac.reclaim.hosting/binary/Vat. Syr. 140_1R_Alaph (Angular)_125_281_28_25.png","id":74761,"top":281,"left":125,"width":28,"height":25},{"page":208,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/VatSyr140/VatSyr140-003.png","letter":2,"binaryurl":"https://images.syriac.reclaim.hosting/binary/Vat. Syr. 140_1R_Alaph (Angular)_212_283_22_20.png","id":74762,"top":283,"left":212,"width":22,"height":20},{"page":208,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/VatSyr140/VatSyr140-003.png","letter":2,"binaryurl":"https://images.syriac.reclaim.hosting/binary/Vat. Syr. 140_1R_Alaph (Angular)_237_278_22_25.png","id":74763,"top":278,"left":237,"width":22,"height":25}],"19":[{"page":7,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/VatSyr140/VatSyr140-291.png","letter":19,"binaryurl":"https://images.syriac.reclaim.hosting/binary/Vat. Syr. 140_145L_Kaph_675_615_15_15.png","id":13256,"top":615,"left":675,"width":15,"height":15},{"page":7,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/VatSyr140/VatSyr140-291.png","letter":19,"binaryurl":"https://images.syriac.reclaim.hosting/binary/Vat. Syr. 140_145L_Kaph_299_214_18_13.png","id":13294,"top":214,"left":299,"width":18,"height":13},{"page":7,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/VatSyr140/VatSyr140-291.png","letter":19,"binaryurl":"https://images.syriac.reclaim.hosting/binary/Vat. Syr. 140_145L_Kaph_608_731_16_15.png","id":13346,"top":731,"left":608,"width":16,"height":15},{"page":208,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/VatSyr140/VatSyr140-003.png","letter":19,"binaryurl":"https://images.syriac.reclaim.hosting/binary/Vat. Syr. 140_1R_Kaph_289_518_18_13.png","id":10180,"top":518,"left":289,"width":18,"height":13},{"page":208,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/VatSyr140/VatSyr140-003.png","letter":19,"binaryurl":"https://images.syriac.reclaim.hosting/binary/Vat. Syr. 140_1R_Kaph_585_808_15_13.png","id":10181,"top":808,"left":585,"width":15,"height":13}],"37":[{"page":7,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/VatSyr140/VatSyr140-291.png","letter":37,"binaryurl":"https://images.syriac.reclaim.hosting/binary/Vat. Syr. 140_145L_Sadhe_432_234_21_21.png","id":13238,"top":234,"left":432,"width":21,"height":21},{"page":7,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/VatSyr140/VatSyr140-291.png","letter":37,"binaryurl":"https://images.syriac.reclaim.hosting/binary/Vat. Syr. 140_145L_Sadhe_420_262_24_19.png","id":13239,"top":262,"left":420,"width":24,"height":19},{"page":7,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/VatSyr140/VatSyr140-291.png","letter":37,"binaryurl":"https://images.syriac.reclaim.hosting/binary/Vat. Syr. 140_145L_Sadhe_624_417_23_21.png","id":13248,"top":417,"left":624,"width":23,"height":21},{"page":7,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/VatSyr140/VatSyr140-291.png","letter":37,"binaryurl":"https://images.syriac.reclaim.hosting/binary/Vat. Syr. 140_145L_Sadhe_647_296_26_21.png","id":13259,"top":296,"left":647,"width":26,"height":21},{"page":208,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/VatSyr140/VatSyr140-003.png","letter":37,"binaryurl":"https://images.syriac.reclaim.hosting/binary/Vat. Syr. 140_1R_Sadhe_760_293_26_17.png","id":10253,"top":293,"left":760,"width":26,"height":17}]},"16":{"2":[{"page":930,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/Add.17224/add17724-57a.jpg","letter":2,"binaryurl":"https://images.syriac.reclaim.hosting/binary/BL. Add. 17224_57a_Alaph (Angular)_759_1756_86_99.png","id":70463,"top":1756,"left":759,"width":86,"height":99},{"page":930,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/Add.17224/add17724-57a.jpg","letter":2,"binaryurl":"https://images.syriac.reclaim.hosting/binary/BL. Add. 17224_57a_Alaph (Angular)_636_1925_95_93.png","id":70464,"top":1925,"left":636,"width":95,"height":93},{"page":930,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/Add.17224/add17724-57a.jpg","letter":2,"binaryurl":"https://images.syriac.reclaim.hosting/binary/BL. Add. 17224_57a_Alaph (Angular)_667_1133_68_75.png","id":70465,"top":1133,"left":667,"width":68,"height":75},{"page":930,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/Add.17224/add17724-57a.jpg","letter":2,"binaryurl":"https://images.syriac.reclaim.hosting/binary/BL. Add. 17224_57a_Alaph (Angular)_1377_1609_72_77.png","id":70466,"top":1609,"left":1377,"width":72,"height":77},{"page":930,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/Add.17224/add17724-57a.jpg","letter":2,"binaryurl":"https://images.syriac.reclaim.hosting/binary/BL. Add. 17224_57a_Alaph (Angular)_1721_1791_86_82.png","id":70467,"top":1791,"left":1721,"width":86,"height":82}],"19":[{"page":930,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/Add.17224/add17724-57a.jpg","letter":19,"binaryurl":"https://images.syriac.reclaim.hosting/binary/BL. Add. 17224_57a_Kaph_976_1150_46_63.png","id":70558,"top":1150,"left":976,"width":46,"height":63},{"page":930,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/Add.17224/add17724-57a.jpg","letter":19,"binaryurl":"https://images.syriac.reclaim.hosting/binary/BL. Add. 17224_57a_Kaph_1083_1970_42_55.png","id":70559,"top":1970,"left":1083,"width":42,"height":55},{"page":930,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/Add.17224/add17724-57a.jpg","letter":19,"binaryurl":"https://images.syriac.reclaim.hosting/binary/BL. Add. 17224_57a_Kaph_1334_2351_46_61.png","id":70560,"top":2351,"left":1334,"width":46,"height":61},{"page":930,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/Add.17224/add17724-57a.jpg","letter":19,"binaryurl":"https://images.syriac.reclaim.hosting/binary/BL. Add. 17224_57a_Kaph_1734_1993_43_57.png","id":70561,"top":1993,"left":1734,"width":43,"height":57},{"page":930,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/Add.17224/add17724-57a.jpg","letter":19,"binaryurl":"https://images.syriac.reclaim.hosting/binary/BL. Add. 17224_57a_Kaph_1354_1708_50_54.png","id":70562,"top":1708,"left":1354,"width":50,"height":54}],"37":[{"page":440,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/Add.17224/add17724-46b.jpg","letter":37,"binaryurl":"https://images.syriac.reclaim.hosting/binary/BL. Add. 17224_46b_Sadhe_843_1144_72_78.png","id":32009,"top":1144,"left":843,"width":72,"height":78},{"page":930,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/Add.17224/add17724-57a.jpg","letter":37,"binaryurl":"https://images.syriac.reclaim.hosting/binary/BL. Add. 17224_57a_Sadhe_1667_2193_83_86.png","id":70663,"top":2193,"left":1667,"width":83,"height":86},{"page":1799,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/Add.17224/add17724-49a.jpg","letter":37,"binaryurl":"https://images.syriac.reclaim.hosting/binary/BL. Add. 17224_49a_Sadhe_713_1940_92_95.png","id":32007,"top":1940,"left":713,"width":92,"height":95},{"page":2147,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/Add.17224/add17724-46a.jpg","letter":37,"binaryurl":"https://images.syriac.reclaim.hosting/binary/BL. Add. 17224_46a_Sadhe_1105_1224_82_82.png","id":70659,"top":1224,"left":1105,"width":82,"height":82},{"page":2147,"pageurl":"https://images.syriac.reclaim.hosting/manuscripts/Add.17224/add17724-46a.jpg","letter":37,"binaryurl":"https://images.syriac.reclaim.hosting/binary/BL. Add. 17224_46a_Sadhe_1616_1408_82_84.png","id":70660,"top":1408,"left":1616,"width":82,"height":84}]}};
-
-export const formData = {"showBinarized":true,"letterExamples":3,"imageSize":"Small","selectedShelfmarks":["Vat. Syr. 112","Vat. Syr. 140","BL. Add. 17224"],"manuscripts":[],"letters":[{"id":2,"letter":"Alaph (Angular)","is_script":true,"display":"ܐ","script":"estrangela"},{"id":25,"letter":"Lamadh (Final, open)","is_script":true,"display":"ܠ","script":"estrangela"},{"id":37,"letter":"Sadhe","is_script":true,"display":"ܨ","script":"estrangela"}]};
 
 export const columns = [{"property":"letter","visible":true,"props":{"style":{"width":80}}},{"property":"row_remover","props":{"style":{"width":45}},"cell":{"formatters":[null]},"visible":true},{"property":"manuscript1","header":{"label":"Vat. Syr. 112","props":{"label":"Vat. Syr. 112"}},"visible":true,"props":{"msid":9,"style":{"width":200}}},{"property":"manuscript2","header":{"label":"Vat. Syr. 140","props":{"label":"Vat. Syr. 140"}},"visible":true,"props":{"msid":11,"style":{"width":200}}},{"property":"manuscript3","header":{"label":"BL. Add. 17224","props":{"label":"BL. Add. 17224"}},"visible":true,"props":{"msid":16,"style":{"width":200}}}];

--- a/js/components/__tests__/LettersLoader.test.js
+++ b/js/components/__tests__/LettersLoader.test.js
@@ -4,9 +4,13 @@ import React from "react";
 import renderer from "react-test-renderer";
 import LettersLoader from "../LettersLoader";
 
+import letters from "../letters.json";
+
 describe("LettersLoader test", () => {
   it("LettersLoader should match snapshot", () => {
-    const component = renderer.create(<LettersLoader />);
+    const component = renderer.create(
+      <LettersLoader selectedLetters={letters.slice(0, 2)} />
+    );
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/js/components/index.css
+++ b/js/components/index.css
@@ -12,3 +12,48 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
 }
+
+.no-padding {
+  padding: 0px 0px;
+}
+
+.tab-icon {
+  color: #0000FF;
+}
+
+.letter-row {
+  margin: "5px";
+  display: "inline-block"
+}
+
+table th {
+  background-color: #f0f0f0;
+  border: 1px solid #dedede;
+  border-bottom-color: rgb(222, 222, 222);
+  border-bottom-color: #c9c9c9;
+}
+
+td img {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+th {
+  padding: 5px;
+  text-align: center;
+}
+
+td {
+  padding: 5px;
+  text-align: left;
+  border: 1px solid #e8e8e8;
+}
+
+td:hover {
+  background-color: #bbbbbb;
+}
+
+tr:nth-child(even) {
+  background-color: #f2f2f2
+}


### PR DESCRIPTION
Major additions to the "Scriptchart options" form:
- Select all/none/invert buttons for manuscripts lists and letters
- Manuscripts list can be sorted by date and time; this order should be reflected in the scriptchart
- Additional radio buttons for choosing letter image type and crop border size (NOTE these will not work until the next PR is merged in)
Some other changes:
- Adding progress/user info prompts to manuscripts list window and scriptchart area
- Removal of in-code style settings to js/components/index.css, consolidation from other CSS files to js/components/index.css (those files will be removed in the next PR)
- Code cleanup, commenting, minor improvements to test setup