### PR TITLE
Manuscript "lineup" management for Mirador, other minor changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ _site
 .sass-cache
 .jekyll-metadata
 .DS_Store
-.snap
 node_modules/
 src/assets/bundle.js
 src/mirador

--- a/js/components/App.js
+++ b/js/components/App.js
@@ -64,8 +64,7 @@ class App extends Component {
     this.processCoords = this.processCoords.bind(this);
     this.getYearFromDate = this.getYearFromDate.bind(this);
     this.sortManuscripts = this.sortManuscripts.bind(this);
-    this.closeSidebar = this.closeSidebar.bind(this);
-    this.openSidebar = this.openSidebar.bind(this);
+    this.toggleSidebar = this.toggleSidebar.bind(this);
   }
 
   /* The ms date field in the DB is a bit unruly. We'll do our best
@@ -141,10 +140,11 @@ class App extends Component {
   }
 
   handleSubmit(formData) {
+    this.setState({
+      showTabs: false,
+      loadingMessage: "Loading manuscripts..."
+    });
 
-    this.setState({ showTabs: false,
-                    loadingMessage: "Loading manuscripts..." });
-    
     let manuscriptQueries = [];
     let manuscripts = [];
     for (let ms of this.state.allManuscripts) {
@@ -174,7 +174,6 @@ class App extends Component {
       this.setState({ loadingMessage: "Loading manuscript pages..." });
 
       for (let pages of msResults) {
-
         for (let page of pages) {
           for (let letter of formData.letters) {
             let coordsQuery =
@@ -193,7 +192,6 @@ class App extends Component {
   }
 
   processCoords(coordsQueries, formData) {
-
     Promise.all(
       coordsQueries.map(url =>
         fetch(url)
@@ -206,10 +204,11 @@ class App extends Component {
     ).then(coordsResults => {
       let tableData = {};
 
-      this.setState({ loadingMessage: "Processing letters on manuscript pages..." });
+      this.setState({
+        loadingMessage: "Processing letters on manuscript pages..."
+      });
 
       for (let coordsData of coordsResults) {
-        
         if (coordsData.length == 0) {
           continue;
         }
@@ -258,13 +257,8 @@ class App extends Component {
     });
   }
 
-  closeSidebar() {
-    this.setState({ sidebarOpen: false });
-    console.log("close the sidebar");
-  }
-
-  openSidebar() {
-    this.setState({ sidebarOpen: true });
+  toggleSidebar() {
+    this.setState({ sidebarOpen: !this.state.sidebarOpen });
   }
 
   componentDidMount() {
@@ -294,10 +288,10 @@ class App extends Component {
               "button column is-narrow closed-menu " +
               (!this.state.sidebarOpen ? "sidebar-open" : "sidebar-closed")
             }
-            onClick={this.openSidebar}
+            onClick={this.toggleSidebar}
           >
             Menu{" "}
-            <span className={"icon arrow-button"} onClick={this.openSidebar}>
+            <span className={"icon arrow-button"} onClick={this.toggleSidebar}>
               <i
                 className={"fa fa-arrow-right"}
                 aria-hidden="true"
@@ -319,7 +313,7 @@ class App extends Component {
                 <div className={"column is-one-quarter"}>
                   <span
                     className={"icon arrow-button"}
-                    onClick={this.closeSidebar}
+                    onClick={this.toggleSidebar}
                   >
                     <i
                       className={"fa fa-arrow-left"}

--- a/js/components/App.js
+++ b/js/components/App.js
@@ -141,11 +141,10 @@ class App extends Component {
   }
 
   handleSubmit(formData) {
-    this.setState({
-      showTabs: false,
-      loadingMessage: "Table data is loading..."
-    });
 
+    this.setState({ showTabs: false,
+                    loadingMessage: "Loading manuscripts..." });
+    
     let manuscriptQueries = [];
     let manuscripts = [];
     for (let ms of this.state.allManuscripts) {
@@ -171,7 +170,11 @@ class App extends Component {
       )
     ).then(msResults => {
       let coordsQueries = [];
+
+      this.setState({ loadingMessage: "Loading manuscript pages..." });
+
       for (let pages of msResults) {
+
         for (let page of pages) {
           for (let letter of formData.letters) {
             let coordsQuery =
@@ -190,6 +193,7 @@ class App extends Component {
   }
 
   processCoords(coordsQueries, formData) {
+
     Promise.all(
       coordsQueries.map(url =>
         fetch(url)
@@ -202,7 +206,10 @@ class App extends Component {
     ).then(coordsResults => {
       let tableData = {};
 
+      this.setState({ loadingMessage: "Processing letters on manuscript pages..." });
+
       for (let coordsData of coordsResults) {
+        
         if (coordsData.length == 0) {
           continue;
         }

--- a/js/components/DashTabs.js
+++ b/js/components/DashTabs.js
@@ -11,6 +11,10 @@ import React from "react";
  * ChartAccordion. As such, it handles dragging and dropping
  * of rows and columns, as well as hiding/redisplaying them.
  *
+ * The component also keeps track of the IIIF manifests available
+ * for display via the Mirador viewer component, as well as the
+ * manifests that are currently "on display" in the viewer.
+ *
  * Conditional rendering: this component displays a text prompt
  * until the configuration form is submitted, at which time it
  * populates the letter and manuscript lists with data that the
@@ -115,8 +119,12 @@ class DashTabs extends React.Component {
     this.setState({ rowLetters });
   }
 
+  /* Note that this helper function can be called before the component
+   * state has been updated with manifest and window object data, so it
+   * always builds these lists from scratch based on the contents
+   * of the "manuscripts" prop.
+   */
   getMiradorParameters() {
-
     let manifestURIs = [];
     let windowObjects = [];
     let miradorLayout = "1x1";
@@ -143,32 +151,27 @@ class DashTabs extends React.Component {
         windowObjects.push(windowObject);
       }
     }
-    return [ manifestURIs, windowObjects, miradorLayout ];
+    return [manifestURIs, windowObjects, miradorLayout];
   }
 
   onManifestSelected(selectedManifestURI) {
-
-    console.log("selected URI is " + selectedManifestURI);
     let manifestURIs = [...this.state.manifestURIs];
     let windowObjects = [...this.state.windowObjects];
     let miradorLayout = this.state.miradorLayout;
 
-    if ((manifestURIs.length == 0) && (this.props.manuscripts)) {
-      console.log("calculating Mirador settings");
-
-      [ manifestURIs, windowObjects, miradorLayout ] = this.getMiradorParameters();
-
+    if (manifestURIs.length == 0 && this.props.manuscripts) {
+      [
+        manifestURIs,
+        windowObjects,
+        miradorLayout
+      ] = this.getMiradorParameters();
     }
 
-    // If the selected manifest is already being shown
-    // in the viewer, do nothing.
-    console.log(windowObjects);
-    console.log(windowObjects.findIndex(o => o.loadedManifest == selectedManifestURI));
-    if (windowObjects.findIndex(o => o.loadedManifest == selectedManifestURI) < 0) {
-      console.log("selected manifest URI is not in windowObjects list");
-
-      // Otherwise, treat the Mirador viewer windows as a LIFO queue
-      // of size 1-4
+    // If the selected manifest is already being shown in the viewer, do nothing.
+    if (
+      windowObjects.findIndex(o => o.loadedManifest == selectedManifestURI) < 0
+    ) {
+      // Otherwise, treat the Mirador viewer windows as a FIFO queue of size 1-4
       if (windowObjects.length == 4) {
         windowObjects.pop();
       }
@@ -179,25 +182,23 @@ class DashTabs extends React.Component {
       };
       windowObjects.unshift(windowObject);
 
-      for (let m=1, len=windowObjects.length; m<len; m++) {
+      for (let m = 1, len = windowObjects.length; m < len; m++) {
         if (m == 1) {
-          windowObjects[m]['targetSlot'] = 'row1.column2';
+          windowObjects[m]["targetSlot"] = "row1.column2";
         } else if (m == 2) {
-          windowObjects[m]['targetSlot'] = 'row2.column1';
+          windowObjects[m]["targetSlot"] = "row2.column1";
         } else if (m == 3) {
-          windowObjects[m]['targetSlot'] = 'row2.column2';
+          windowObjects[m]["targetSlot"] = "row2.column2";
         }
       }
 
-      let miradorLayout = '1x1';
+      let miradorLayout = "1x1";
       if (windowObjects.length == 2) {
-        miradorLayout = '1x2';
+        miradorLayout = "1x2";
       } else if (windowObjects.length >= 3) {
-        miradorLayout = '2x2';
+        miradorLayout = "2x2";
       }
     }
-    console.log("after Mirador LIFO");
-    console.log(windowObjects);
 
     this.setState({ manifestURIs, windowObjects, miradorLayout, tabIndex: 1 });
   }
@@ -285,21 +286,13 @@ class DashTabs extends React.Component {
     let windowObjects = [...this.state.windowObjects];
     let miradorLayout = this.state.miradorLayout;
 
-    console.log("checking preconditions for Mirador render");
-    console.log(manifestURIs.length);
-    console.log(this.props.manuscripts);
-
-    if ((manifestURIs.length == 0) && (this.props.manuscripts)) {
-      console.log("calculating Mirador settings");
-
-      [ manifestURIs, windowObjects, miradorLayout ] = this.getMiradorParameters();
-
+    if (manifestURIs.length == 0 && this.props.manuscripts) {
+      [
+        manifestURIs,
+        windowObjects,
+        miradorLayout
+      ] = this.getMiradorParameters();
     }
-    console.log("on DashTabs render:");
-    console.log(manifestURIs);
-    console.log(windowObjects);
-    console.log(miradorLayout);
-    //this.setState({ manifestURIs, windowObjects, miradorLayout });
 
     return (
       <section className="section no-padding">

--- a/js/components/ManuscriptForm.js
+++ b/js/components/ManuscriptForm.js
@@ -72,30 +72,34 @@ class ManuscriptForm extends React.Component {
     this.handleSelect("letters", selectedLetters);
   }
 
+  // Currently this is a simple all/none toggle
   lettersSelect(event) {
-    const which = event.target.textContent;
-    let selectedLetters = [];
-    if (which != "Select none") {
-      selectedLetters = [...this.state.letters];
-      for (let lt of letters) {
-        let ltid = lt.id;
-        if (
-          which == "Select all" &&
-          selectedLetters.findIndex(l => l.id == ltid) < 0
-        ) {
-          selectedLetters.push(lt);
-        } /*else if (which == "Invert selection") {
-          if (selectedLetters.findIndex(l => l.id == ltid) < 0) {
-            selectedLetters.push(lt);
-          } else {
-            selectedLetters.splice(
-              selectedLetters.findIndex(l => l.id == ltid),
-              1
-            );
-          }
-        }*/
+    //const which = event.target.textContent;
+    //let selectedLetters = [];
+    //if (which != "None") {
+    let selectedLetters = [...this.state.letters];
+    for (let lt of letters) {
+      let ltid = lt.id;
+      if (//which == "All" &&
+        selectedLetters.findIndex(l => l.id == ltid) < 0
+      ) {
+        selectedLetters.push(lt);
+      } else {
+        selectedLetters = [];
+        break;
       }
+      /*else if (which == "Invert selection") {
+        if (selectedLetters.findIndex(l => l.id == ltid) < 0) {
+          selectedLetters.push(lt);
+        } else {
+          selectedLetters.splice(
+            selectedLetters.findIndex(l => l.id == ltid),
+            1
+          );
+        }
+      }*/
     }
+    //}
     this.handleSelect("letters", selectedLetters);
   }
 
@@ -138,15 +142,15 @@ class ManuscriptForm extends React.Component {
           sortManuscripts={this.props.sortManuscripts}
         />
         <div className={"field"}>
-          <label className={"control"}>Select letters:</label>
           <div className={"control"} style={{ marginBottom: 5 }}>
+            <label className={"control"}>Select letters: </label>
             <span className="button is-small" onClick={this.lettersSelect}>
-              Select all
-            </span>
-            <span className="button is-small" onClick={this.lettersSelect}>
-              Select none
+              All/None
             </span>
             {/*<span className="button is-small" onClick={this.lettersSelect}>
+              None
+            </span>
+            <span className="button is-small" onClick={this.lettersSelect}>
               Invert selection
             </span>*/}
           </div>

--- a/js/components/ManuscriptForm.js
+++ b/js/components/ManuscriptForm.js
@@ -26,7 +26,6 @@ class ManuscriptForm extends React.Component {
       imageDisplay: "hover",
       imageSize: "Small",
       selectedShelfmarks: [],
-      manuscripts: [],
       letters: []
     };
 
@@ -85,7 +84,7 @@ class ManuscriptForm extends React.Component {
           selectedLetters.findIndex(l => l.id == ltid) < 0
         ) {
           selectedLetters.push(lt);
-        } else if (which == "Invert selection") {
+        } /*else if (which == "Invert selection") {
           if (selectedLetters.findIndex(l => l.id == ltid) < 0) {
             selectedLetters.push(lt);
           } else {
@@ -94,7 +93,7 @@ class ManuscriptForm extends React.Component {
               1
             );
           }
-        }
+        }*/
       }
     }
     this.handleSelect("letters", selectedLetters);
@@ -147,9 +146,9 @@ class ManuscriptForm extends React.Component {
             <span className="button is-small" onClick={this.lettersSelect}>
               Select none
             </span>
-            <span className="button is-small" onClick={this.lettersSelect}>
+            {/*<span className="button is-small" onClick={this.lettersSelect}>
               Invert selection
-            </span>
+            </span>*/}
           </div>
           <LettersLoader
             selectedLetters={this.state.letters}

--- a/js/components/ManuscriptMenu.js
+++ b/js/components/ManuscriptMenu.js
@@ -45,13 +45,13 @@ class ManuscriptMenu extends React.Component {
         let sm = ms.shelfmark;
         if (which == "Select all" && selectedShelfmarks.indexOf(sm) < 0) {
           selectedShelfmarks.push(sm);
-        } else if (which == "Invert selection") {
+        } /* else if (which == "Invert selection") {
           if (selectedShelfmarks.indexOf(sm) < 0) {
             selectedShelfmarks.push(sm);
           } else {
             selectedShelfmarks.splice(selectedShelfmarks.indexOf(sm), 1);
           }
-        }
+        }*/
       }
     }
     this.props.handleSelect("selectedShelfmarks", selectedShelfmarks);
@@ -80,9 +80,9 @@ class ManuscriptMenu extends React.Component {
           <span className="button is-small" onClick={this.manuscriptsSelect}>
             Select none
           </span>
-          <span className="button is-small" onClick={this.manuscriptsSelect}>
+          {/*<span className="button is-small" onClick={this.manuscriptsSelect}>
             Invert selection
-          </span>
+          </span>*/}
         </div>
         <div className={"select is-multiple"}>
           <ManuscriptsLoader

--- a/js/components/ManuscriptMenu.js
+++ b/js/components/ManuscriptMenu.js
@@ -34,25 +34,31 @@ class ManuscriptMenu extends React.Component {
     this.props.handleSelect(name, value);
   }
 
+  // Currently this is a simple all/none toggle
   manuscriptsSelect(event) {
-    const which = event.target.textContent;
-    let selectedShelfmarks = [];
-    if (which != "Select none") {
-      selectedShelfmarks = JSON.parse(
-        JSON.stringify(this.props.selectedShelfmarks)
-      );
-      for (let ms of this.props.manuscripts) {
-        let sm = ms.shelfmark;
-        if (which == "Select all" && selectedShelfmarks.indexOf(sm) < 0) {
-          selectedShelfmarks.push(sm);
-        } /* else if (which == "Invert selection") {
+    //const which = event.target.textContent;
+    //let selectedShelfmarks = [];
+    //if (which != "None") {
+    let selectedShelfmarks = JSON.parse(
+      JSON.stringify(this.props.selectedShelfmarks)
+    );
+    for (let ms of this.props.manuscripts) {
+      let sm = ms.shelfmark;
+      if (//which == "All" &&
+        selectedShelfmarks.indexOf(sm) < 0) {
+        selectedShelfmarks.push(sm);
+      } else {
+        selectedShelfmarks = [];
+        break;
+      }
+      /* else if (which == "Invert selection") {
           if (selectedShelfmarks.indexOf(sm) < 0) {
             selectedShelfmarks.push(sm);
           } else {
             selectedShelfmarks.splice(selectedShelfmarks.indexOf(sm), 1);
           }
         }*/
-      }
+      //}
     }
     this.props.handleSelect("selectedShelfmarks", selectedShelfmarks);
   }
@@ -72,15 +78,15 @@ class ManuscriptMenu extends React.Component {
   render() {
     return (
       <div className={"field"}>
-        <label className={"control"}>Select manuscripts:</label>
         <div className={"control"} style={{ marginBottom: 5 }}>
+          <label className={"control"}>Select manuscripts: </label>
           <span className="button is-small" onClick={this.manuscriptsSelect}>
-            Select all
-          </span>
-          <span className="button is-small" onClick={this.manuscriptsSelect}>
-            Select none
+            All/None
           </span>
           {/*<span className="button is-small" onClick={this.manuscriptsSelect}>
+            None
+          </span>
+          <span className="button is-small" onClick={this.manuscriptsSelect}>
             Invert selection
           </span>*/}
         </div>

--- a/js/components/MiradorViewer.css
+++ b/js/components/MiradorViewer.css
@@ -1,3 +1,4 @@
 .mirador-container .mirador-viewer {
     height: 100vh;
+    margin-top: 55px;
 }

--- a/js/components/MiradorViewer.jsx
+++ b/js/components/MiradorViewer.jsx
@@ -6,12 +6,8 @@ import React, { Component } from "react";
 
 import "./MiradorViewer.css";
 
-export default class MiradorViewer extends Component {  
+export default class MiradorViewer extends Component {
   componentDidMount() {
-    console.log("Mounting Mirador viewer:");
-    console.log(this.props.manifestURIs);
-    console.log(this.props.windowObjects);
-    console.log(this.props.miradorLayout);
     Mirador({
       id: "mirador",
       layout: this.props.miradorLayout,

--- a/js/components/MiradorViewer.jsx
+++ b/js/components/MiradorViewer.jsx
@@ -6,49 +6,18 @@ import React, { Component } from "react";
 
 import "./MiradorViewer.css";
 
-export default class MiradorViewer extends Component {
+export default class MiradorViewer extends Component {  
   componentDidMount() {
+    console.log("Mounting Mirador viewer:");
+    console.log(this.props.manifestURIs);
+    console.log(this.props.windowObjects);
+    console.log(this.props.miradorLayout);
     Mirador({
       id: "mirador",
-      layout: "1x1",
+      layout: this.props.miradorLayout,
       buildPath: "mirador/",
-      /* XXX Eventually need to be able to load multiple MSs dynamically */
-      data: [
-        {
-          manifestUri: this.props.manifestURL,
-          location: "Stanford University"
-        },
-        {
-          manifestUri: "https://iiif.lib.harvard.edu/manifests/drs:42715137",
-          location: "Harvard Library"
-        },
-        {
-          manifestUri:
-            "https://digi.vatlib.it/iiif/MSS_Vat.sir.157/manifest.json",
-          location: "Biblioteca Apostolica Vaticana"
-        },
-        {
-          manifestUri:
-            "https://digi.vatlib.it/iiif/MSS_Vat.sir.161/manifest.json",
-          location: "Biblioteca Apostolica Vaticana"
-        },
-        {
-          manifestUri:
-            "https://gallica.bnf.fr/iiif/ark:/12148/btv1b531151912/manifest.json",
-          location: "Bibliotheque Nationale"
-        },
-        {
-          manifestUri:
-            "https://gallica.bnf.fr/iiif/ark:/12148/btv1b10528606c/manifest.json",
-          location: "Bibliotheque Nationale"
-        }
-      ],
-      windowObjects: [
-        {
-          loadedManifest: this.props.manifestURL,
-          viewType: "ImageView"
-        }
-      ],
+      data: this.props.manifestURIs,
+      windowObjects: this.props.windowObjects,
       annotationEndpoint: {
         name: "Local Storage",
         module: "LocalStorageEndpoint"

--- a/js/components/__tests__/__snapshots__/App.test.js.snap
+++ b/js/components/__tests__/__snapshots__/App.test.js.snap
@@ -92,12 +92,6 @@ exports[`App test App should match snapshot 1`] = `
                 >
                   Select none
                 </span>
-                <span
-                  className="button is-small"
-                  onClick={[Function]}
-                >
-                  Invert selection
-                </span>
               </div>
               <div
                 className="select is-multiple"
@@ -174,12 +168,6 @@ exports[`App test App should match snapshot 1`] = `
                   onClick={[Function]}
                 >
                   Select none
-                </span>
-                <span
-                  className="button is-small"
-                  onClick={[Function]}
-                >
-                  Invert selection
                 </span>
               </div>
               <div

--- a/js/components/__tests__/__snapshots__/ChartAccordion.test.js.snap
+++ b/js/components/__tests__/__snapshots__/ChartAccordion.test.js.snap
@@ -64,6 +64,7 @@ exports[`ChartAccordion test ChartAccordion should match snapshot 1`] = `
         className="buttons are-small"
       >
         <LetterButton
+          buttonClass="button is-outlined"
           key="2"
           letter={
             <SyriacLetter
@@ -73,6 +74,7 @@ exports[`ChartAccordion test ChartAccordion should match snapshot 1`] = `
           letterID={2}
         />
         <LetterButton
+          buttonClass="button is-outlined"
           key="4"
           letter={
             <SyriacLetter
@@ -82,6 +84,7 @@ exports[`ChartAccordion test ChartAccordion should match snapshot 1`] = `
           letterID={4}
         />
         <LetterButton
+          buttonClass="button is-outlined"
           key="9"
           letter={
             <SyriacLetter

--- a/js/components/__tests__/__snapshots__/LetterButton.test.js.snap
+++ b/js/components/__tests__/__snapshots__/LetterButton.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`LetterButton test LetterButton should match snapshot 1`] = `
 <span
-  className="button is-outlined"
   onClick={[Function]}
 />
 `;

--- a/js/components/__tests__/__snapshots__/LetterImage.test.js.snap
+++ b/js/components/__tests__/__snapshots__/LetterImage.test.js.snap
@@ -2,14 +2,12 @@
 
 exports[`LetterImage test LetterImage should match snapshot 1`] = `
 <span
-  style={
-    Object {
-      "display": "inline-block",
-    }
-  }
+  className="letter-row"
 >
   <img
     height={100}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
     width={55}
   />
 </span>

--- a/js/components/__tests__/__snapshots__/LettersLoader.test.js.snap
+++ b/js/components/__tests__/__snapshots__/LettersLoader.test.js.snap
@@ -5,7 +5,7 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
   className="buttons are-small"
 >
   <span
-    className="button is-outlined"
+    className="button is-success"
     onClick={[Function]}
   >
     <span
@@ -24,7 +24,7 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
     </span>
   </span>
   <span
-    className="button is-outlined"
+    className="button is-success"
     onClick={[Function]}
   >
     <span

--- a/js/components/__tests__/__snapshots__/ManuscriptForm.test.js.snap
+++ b/js/components/__tests__/__snapshots__/ManuscriptForm.test.js.snap
@@ -11,113 +11,175 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
     <label
       className="control"
     >
-      Select Manuscripts:
+      Select manuscripts:
     </label>
     <div
       className="control"
+      style={
+        Object {
+          "marginBottom": 5,
+        }
+      }
     >
-      <div
-        className="select is-multiple"
+      <span
+        className="button is-small"
+        onClick={[Function]}
       >
-        <select
-          multiple={true}
-          name="selectedShelfmarks"
-          onChange={[Function]}
-          type="string"
-          value={Array []}
-        >
-          <option
-            value="Vat. Syr. 092"
-          >
-            Vat. Syr. 092
-          </option>
-          <option
-            value="Vat. Syr. 112"
-          >
-            Vat. Syr. 112
-          </option>
-          <option
-            value="Vat. Syr. 140"
-          >
-            Vat. Syr. 140
-          </option>
-          <option
-            value="BL. Add. 17224"
-          >
-            BL. Add. 17224
-          </option>
-          <option
-            value="BL. Add. 12144"
-          >
-            BL. Add. 12144
-          </option>
-          <option
-            value="BL. Add. 12134"
-          >
-            BL. Add. 12134
-          </option>
-          <option
-            value="BL. Add. 14445"
-          >
-            BL. Add. 14445
-          </option>
-          <option
-            value="BL. Add. 12146"
-          >
-            BL. Add. 12146
-          </option>
-          <option
-            value="BL. Or. 8732"
-          >
-            BL. Or. 8732
-          </option>
-          <option
-            value="BL. Or. 8606"
-          >
-            BL. Or. 8606
-          </option>
-          <option
-            value="BL. Add. 17102"
-          >
-            BL. Add. 17102
-          </option>
-          <option
-            value="BL. Add. 17107"
-          >
-            BL. Add. 17107
-          </option>
-          <option
-            value="BL. Add. 12175"
-          >
-            BL. Add. 12175
-          </option>
-        </select>
-      </div>
+        Select all
+      </span>
+      <span
+        className="button is-small"
+        onClick={[Function]}
+      >
+        Select none
+      </span>
     </div>
     <div
-      className="control sort-option"
+      className="select is-multiple"
+    >
+      <select
+        multiple={true}
+        name="selectedShelfmarks"
+        onChange={[Function]}
+        size="8"
+        type="string"
+        value={Array []}
+      >
+        <option
+          value="Vat. Syr. 092"
+        >
+          Vat. Syr. 092
+           (
+          823
+          )
+        </option>
+        <option
+          value="Vat. Syr. 112"
+        >
+          Vat. Syr. 112
+           (
+          552
+          )
+        </option>
+        <option
+          value="Vat. Syr. 140"
+        >
+          Vat. Syr. 140
+           (
+          528
+          )
+        </option>
+        <option
+          value="BL. Add. 17224"
+        >
+          BL. Add. 17224
+           (
+          1173
+          )
+        </option>
+        <option
+          value="BL. Add. 12144"
+        >
+          BL. Add. 12144
+           (
+          1081
+          )
+        </option>
+        <option
+          value="BL. Add. 12134"
+        >
+          BL. Add. 12134
+           (
+          697
+          )
+        </option>
+        <option
+          value="BL. Add. 14445"
+        >
+          BL. Add. 14445
+           (
+          532
+          )
+        </option>
+        <option
+          value="BL. Add. 12146"
+        >
+          BL. Add. 12146
+           (
+          1007
+          )
+        </option>
+        <option
+          value="BL. Or. 8732"
+        >
+          BL. Or. 8732
+           (
+          770
+          )
+        </option>
+        <option
+          value="BL. Or. 8606"
+        >
+          BL. Or. 8606
+           (
+          723
+          )
+        </option>
+        <option
+          value="BL. Add. 17102"
+        >
+          BL. Add. 17102
+           (
+          598-599
+          )
+        </option>
+        <option
+          value="BL. Add. 17107"
+        >
+          BL. Add. 17107
+           (
+          540-541
+          )
+        </option>
+        <option
+          value="BL. Add. 12175"
+        >
+          BL. Add. 12175
+           (
+          533-534
+          )
+        </option>
+      </select>
+    </div>
+    <div
+      className="control"
     >
       <p>
-        Order manuscripts by:
+        Order manuscripts by
       </p>
       <label
         className="radio"
       >
-        Shelfmark:
         <input
-          defaultChecked={true}
-          name="Shelfmark"
+          checked={true}
+          onChange={[Function]}
           type="radio"
+          value="shelfmark"
         />
+         
+        Shelfmark |
       </label>
       <label
         className="radio"
       >
-        Date:
         <input
-          name="Date"
+          checked={false}
+          onChange={[Function]}
           type="radio"
+          value="date"
         />
+         
+        Date
       </label>
     </div>
   </div>
@@ -127,8 +189,29 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
     <label
       className="control"
     >
-      Select Letters:
+      Select letters:
     </label>
+    <div
+      className="control"
+      style={
+        Object {
+          "marginBottom": 5,
+        }
+      }
+    >
+      <span
+        className="button is-small"
+        onClick={[Function]}
+      >
+        Select all
+      </span>
+      <span
+        className="button is-small"
+        onClick={[Function]}
+      >
+        Select none
+      </span>
+    </div>
     <div
       className="buttons are-small"
     >
@@ -864,83 +947,202 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
     </div>
   </div>
   <div
-    className="field"
+    className="field is-horizontal"
   >
-    <label
-      className="control"
-    >
-      Select number of letter examples:
-    </label>
     <div
-      className="control"
+      className="field-label is-normal"
     >
       <div
-        className="select"
+        style={
+          Object {
+            "whiteSpace": "nowrap",
+          }
+        }
       >
-        <select
-          name="letterExamples"
-          onChange={[Function]}
-          type="number"
-          value={3}
+        Number of letter examples:
+      </div>
+    </div>
+    <div
+      className="field-body"
+    >
+      <div
+        className="field is-narrow"
+      >
+        <div
+          className="control"
         >
-          <option>
-            1
-          </option>
-          <option>
-            3
-          </option>
-          <option>
-            5
-          </option>
-        </select>
+          <div
+            className="select is-small is-fullwidth"
+          >
+            <select
+              name="letterExamples"
+              onChange={[Function]}
+              type="number"
+              value={3}
+            >
+              <option>
+                1
+              </option>
+              <option>
+                3
+              </option>
+              <option>
+                5
+              </option>
+            </select>
+          </div>
+        </div>
       </div>
     </div>
   </div>
   <div
-    className="field"
+    className="field is-horizontal"
   >
-    <label
-      className="checkbox"
-    >
-      Show binarized images?
-      <input
-        checked={true}
-        name="showBinarized"
-        onChange={[Function]}
-        type="checkbox"
-      />
-    </label>
-  </div>
-  <div
-    className="field"
-  >
-    <label
-      className="control"
-    >
-      Select image size:
-    </label>
     <div
-      className="control"
+      className="field-label is-normal"
     >
       <div
-        className="select"
+        style={
+          Object {
+            "whiteSpace": "nowrap",
+          }
+        }
       >
-        <select
-          name="imageSize"
-          onChange={[Function]}
-          type="string"
-          value="Small"
+        Select image size:
+      </div>
+    </div>
+    <div
+      className="field-body"
+    >
+      <div
+        className="field is-narrow"
+      >
+        <div
+          className="control"
         >
-          <option>
-            Small
-          </option>
-          <option>
-            Medium
-          </option>
-          <option>
-            Large
-          </option>
-        </select>
+          <div
+            className="select is-small is-fullwidth"
+          >
+            <select
+              disabled={false}
+              name="imageSize"
+              onChange={[Function]}
+              type="string"
+              value="Small"
+            >
+              <option>
+                Small
+              </option>
+              <option>
+                Medium
+              </option>
+              <option>
+                Large
+              </option>
+            </select>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="control"
+  >
+    <p>
+      Letter image options:
+    </p>
+    <ul>
+      <li>
+        <label
+          className="radio"
+        >
+          <input
+            checked={false}
+            onChange={[Function]}
+            type="radio"
+            value="binarized"
+          />
+           
+          Show binarized only
+        </label>
+      </li>
+      <li>
+        <label
+          className="radio"
+        >
+          <input
+            checked={true}
+            onChange={[Function]}
+            type="radio"
+            value="hover"
+          />
+           
+          Show cropped images on hover
+        </label>
+      </li>
+      <li>
+        <label
+          className="radio"
+        >
+          <input
+            checked={false}
+            onChange={[Function]}
+            type="radio"
+            value="cropped"
+          />
+           
+          Show cropped images only
+        </label>
+      </li>
+    </ul>
+  </div>
+  <div
+    className="field is-horizontal"
+  >
+    <div
+      className="field-label is-normal"
+    >
+      <div
+        style={
+          Object {
+            "whiteSpace": "nowrap",
+          }
+        }
+      >
+        Cropped margin size:
+      </div>
+    </div>
+    <div
+      className="field-body"
+    >
+      <div
+        className="field is-narrow"
+      >
+        <div
+          className="control"
+        >
+          <div
+            className="select is-small is-fullwidth"
+          >
+            <select
+              disabled={false}
+              name="cropMargin"
+              onChange={[Function]}
+              type="string"
+              value="Medium"
+            >
+              <option>
+                None
+              </option>
+              <option>
+                Medium
+              </option>
+              <option>
+                Large
+              </option>
+            </select>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/js/components/__tests__/__snapshots__/ManuscriptMenu.test.js.snap
+++ b/js/components/__tests__/__snapshots__/ManuscriptMenu.test.js.snap
@@ -7,113 +7,174 @@ exports[`ManuscriptMenu test ManuscriptMenu should match snapshot 1`] = `
   <label
     className="control"
   >
-    Select Manuscripts:
+    Select manuscripts:
   </label>
   <div
     className="control"
+    style={
+      Object {
+        "marginBottom": 5,
+      }
+    }
   >
-    <div
-      className="select is-multiple"
+    <span
+      className="button is-small"
+      onClick={[Function]}
     >
-      <select
-        multiple={true}
-        name="selectedShelfmarks"
-        onChange={[Function]}
-        type="string"
-        value={Array []}
-      >
-        <option
-          value="Vat. Syr. 092"
-        >
-          Vat. Syr. 092
-        </option>
-        <option
-          value="Vat. Syr. 112"
-        >
-          Vat. Syr. 112
-        </option>
-        <option
-          value="Vat. Syr. 140"
-        >
-          Vat. Syr. 140
-        </option>
-        <option
-          value="BL. Add. 17224"
-        >
-          BL. Add. 17224
-        </option>
-        <option
-          value="BL. Add. 12144"
-        >
-          BL. Add. 12144
-        </option>
-        <option
-          value="BL. Add. 12134"
-        >
-          BL. Add. 12134
-        </option>
-        <option
-          value="BL. Add. 14445"
-        >
-          BL. Add. 14445
-        </option>
-        <option
-          value="BL. Add. 12146"
-        >
-          BL. Add. 12146
-        </option>
-        <option
-          value="BL. Or. 8732"
-        >
-          BL. Or. 8732
-        </option>
-        <option
-          value="BL. Or. 8606"
-        >
-          BL. Or. 8606
-        </option>
-        <option
-          value="BL. Add. 17102"
-        >
-          BL. Add. 17102
-        </option>
-        <option
-          value="BL. Add. 17107"
-        >
-          BL. Add. 17107
-        </option>
-        <option
-          value="BL. Add. 12175"
-        >
-          BL. Add. 12175
-        </option>
-      </select>
-    </div>
+      Select all
+    </span>
+    <span
+      className="button is-small"
+      onClick={[Function]}
+    >
+      Select none
+    </span>
   </div>
   <div
-    className="control sort-option"
+    className="select is-multiple"
+  >
+    <select
+      multiple={true}
+      name="selectedShelfmarks"
+      onChange={[Function]}
+      size="8"
+      type="string"
+    >
+      <option
+        value="Vat. Syr. 092"
+      >
+        Vat. Syr. 092
+         (
+        823
+        )
+      </option>
+      <option
+        value="Vat. Syr. 112"
+      >
+        Vat. Syr. 112
+         (
+        552
+        )
+      </option>
+      <option
+        value="Vat. Syr. 140"
+      >
+        Vat. Syr. 140
+         (
+        528
+        )
+      </option>
+      <option
+        value="BL. Add. 17224"
+      >
+        BL. Add. 17224
+         (
+        1173
+        )
+      </option>
+      <option
+        value="BL. Add. 12144"
+      >
+        BL. Add. 12144
+         (
+        1081
+        )
+      </option>
+      <option
+        value="BL. Add. 12134"
+      >
+        BL. Add. 12134
+         (
+        697
+        )
+      </option>
+      <option
+        value="BL. Add. 14445"
+      >
+        BL. Add. 14445
+         (
+        532
+        )
+      </option>
+      <option
+        value="BL. Add. 12146"
+      >
+        BL. Add. 12146
+         (
+        1007
+        )
+      </option>
+      <option
+        value="BL. Or. 8732"
+      >
+        BL. Or. 8732
+         (
+        770
+        )
+      </option>
+      <option
+        value="BL. Or. 8606"
+      >
+        BL. Or. 8606
+         (
+        723
+        )
+      </option>
+      <option
+        value="BL. Add. 17102"
+      >
+        BL. Add. 17102
+         (
+        598-599
+        )
+      </option>
+      <option
+        value="BL. Add. 17107"
+      >
+        BL. Add. 17107
+         (
+        540-541
+        )
+      </option>
+      <option
+        value="BL. Add. 12175"
+      >
+        BL. Add. 12175
+         (
+        533-534
+        )
+      </option>
+    </select>
+  </div>
+  <div
+    className="control"
   >
     <p>
-      Order manuscripts by:
+      Order manuscripts by
     </p>
     <label
       className="radio"
     >
-      Shelfmark:
       <input
-        defaultChecked={true}
-        name="Shelfmark"
+        checked={true}
+        onChange={[Function]}
         type="radio"
+        value="shelfmark"
       />
+       
+      Shelfmark |
     </label>
     <label
       className="radio"
     >
-      Date:
       <input
-        name="Date"
+        checked={false}
+        onChange={[Function]}
         type="radio"
+        value="date"
       />
+       
+      Date
     </label>
   </div>
 </div>

--- a/js/components/__tests__/__snapshots__/ManuscriptsLoader.test.js.snap
+++ b/js/components/__tests__/__snapshots__/ManuscriptsLoader.test.js.snap
@@ -4,74 +4,112 @@ exports[`ManuscriptsLoader test ManuscriptsLoader should match snapshot 1`] = `
 <select
   multiple={true}
   name="selectedShelfmarks"
-  onChange={[Function]}
+  size="8"
   type="string"
-  value={Array []}
 >
   <option
     value="Vat. Syr. 092"
   >
     Vat. Syr. 092
+     (
+    823
+    )
   </option>
   <option
     value="Vat. Syr. 112"
   >
     Vat. Syr. 112
+     (
+    552
+    )
   </option>
   <option
     value="Vat. Syr. 140"
   >
     Vat. Syr. 140
+     (
+    528
+    )
   </option>
   <option
     value="BL. Add. 17224"
   >
     BL. Add. 17224
+     (
+    1173
+    )
   </option>
   <option
     value="BL. Add. 12144"
   >
     BL. Add. 12144
+     (
+    1081
+    )
   </option>
   <option
     value="BL. Add. 12134"
   >
     BL. Add. 12134
+     (
+    697
+    )
   </option>
   <option
     value="BL. Add. 14445"
   >
     BL. Add. 14445
+     (
+    532
+    )
   </option>
   <option
     value="BL. Add. 12146"
   >
     BL. Add. 12146
+     (
+    1007
+    )
   </option>
   <option
     value="BL. Or. 8732"
   >
     BL. Or. 8732
+     (
+    770
+    )
   </option>
   <option
     value="BL. Or. 8606"
   >
     BL. Or. 8606
+     (
+    723
+    )
   </option>
   <option
     value="BL. Add. 17102"
   >
     BL. Add. 17102
+     (
+    598-599
+    )
   </option>
   <option
     value="BL. Add. 17107"
   >
     BL. Add. 17107
+     (
+    540-541
+    )
   </option>
   <option
     value="BL. Add. 12175"
   >
     BL. Add. 12175
+     (
+    533-534
+    )
   </option>
 </select>
 `;

--- a/js/components/index.css
+++ b/js/components/index.css
@@ -1,15 +1,15 @@
 body {
   margin: 0;
   padding: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
+    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue,
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
+  font-family: source-code-pro, Menlo, Monaco, Consolas, Courier New,
     monospace;
 }
 
@@ -22,8 +22,8 @@ code {
 }
 
 .letter-row {
-  margin: "5px";
-  display: "inline-block"
+  margin: 5px;
+  display: inline-block
 }
 
 table th {


### PR DESCRIPTION
- When the scriptchart options form is submitted, DashTabs builds a list of all available manifests for the selected manuscripts, as well as contents and locations of up to 4 content windows, to be passed to the Mirador viewer component.
- Selecting the blue "show in Mirador" button for a manuscript not currently on display in the Mirador viewer adds that manuscript to the viewer, possibly kicking out one of the previous displayed manifests if the total number has reached 4.
- Marginally more informative loading/status messages.
- Hard-coded a top margin on the Mirador viewer to keep the window from displaying over the top of the menu bar, which otherwise happens for some reason.
- Nitpicking of sidebar collapse/toggle code.
- Adding testing snapshots to the repo.