### PR TITLE
Use zero-width joiner for medial and final letters

### DIFF
--- a/js/components/SyriacLetter.js
+++ b/js/components/SyriacLetter.js
@@ -33,18 +33,10 @@ class SyriacLetter extends React.Component {
        * XXX This trick may only work in Firefox :-(
        * */
       if (this.letter.hasOwnProperty("trailing_letter")) {
-        this.trailing = (
-          <span style={{ color: "transparent" }}>
-            {this.letter.trailing_letter}
-          </span>
-        );
+        this.trailing = this.letter.trailing_letter;
       }
       if (this.letter.hasOwnProperty("leading_letter")) {
-        this.leading = (
-          <span style={{ color: "transparent" }}>
-            {this.letter.leading_letter}
-          </span>
-        );
+        this.leading = this.letter.leading_letter;
       }
     } else {
       if (this.props.hasOwnProperty("letter")) {

--- a/js/components/__tests__/__snapshots__/App.test.js.snap
+++ b/js/components/__tests__/__snapshots__/App.test.js.snap
@@ -416,25 +416,9 @@ exports[`App test App should match snapshot 1`] = `
                     }
                     title="ܝ"
                   >
-                    <span
-                      style={
-                        Object {
-                          "color": "transparent",
-                        }
-                      }
-                    >
-                      ܝ
-                    </span>
+                    ‍
                     ܝ
-                    <span
-                      style={
-                        Object {
-                          "color": "transparent",
-                        }
-                      }
-                    >
-                      ܝ
-                    </span>
+                    ‍
                   </span>
                 </span>
                 <span
@@ -472,15 +456,7 @@ exports[`App test App should match snapshot 1`] = `
                   >
                     
                     ܟ
-                    <span
-                      style={
-                        Object {
-                          "color": "transparent",
-                        }
-                      }
-                    >
-                      ܝ
-                    </span>
+                    ‍
                   </span>
                 </span>
                 <span
@@ -535,15 +511,7 @@ exports[`App test App should match snapshot 1`] = `
                     }
                     title="ܠ"
                   >
-                    <span
-                      style={
-                        Object {
-                          "color": "transparent",
-                        }
-                      }
-                    >
-                      ܝ
-                    </span>
+                    ‍
                     ܠ
                     
                   </span>
@@ -583,15 +551,7 @@ exports[`App test App should match snapshot 1`] = `
                   >
                     
                     ܡ
-                    <span
-                      style={
-                        Object {
-                          "color": "transparent",
-                        }
-                      }
-                    >
-                      ܝ
-                    </span>
+                    ‍
                   </span>
                 </span>
                 <span
@@ -629,15 +589,7 @@ exports[`App test App should match snapshot 1`] = `
                   >
                     
                     ܢ
-                    <span
-                      style={
-                        Object {
-                          "color": "transparent",
-                        }
-                      }
-                    >
-                      ܝ
-                    </span>
+                    ‍
                   </span>
                 </span>
                 <span
@@ -654,15 +606,7 @@ exports[`App test App should match snapshot 1`] = `
                     }
                     title="ܢ"
                   >
-                    <span
-                      style={
-                        Object {
-                          "color": "transparent",
-                        }
-                      }
-                    >
-                      ܝ
-                    </span>
+                    ‍
                     ܢ
                     
                   </span>
@@ -871,15 +815,7 @@ exports[`App test App should match snapshot 1`] = `
                     }
                     title="ܬ"
                   >
-                    <span
-                      style={
-                        Object {
-                          "color": "transparent",
-                        }
-                      }
-                    >
-                      ܝ
-                    </span>
+                    ‍
                     ܬ
                     
                   </span>

--- a/js/components/__tests__/__snapshots__/LettersLoader.test.js.snap
+++ b/js/components/__tests__/__snapshots__/LettersLoader.test.js.snap
@@ -246,25 +246,9 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
       }
       title="ܝ"
     >
-      <span
-        style={
-          Object {
-            "color": "transparent",
-          }
-        }
-      >
-        ܝ
-      </span>
+      ‍
       ܝ
-      <span
-        style={
-          Object {
-            "color": "transparent",
-          }
-        }
-      >
-        ܝ
-      </span>
+      ‍
     </span>
   </span>
   <span
@@ -302,15 +286,7 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
     >
       
       ܟ
-      <span
-        style={
-          Object {
-            "color": "transparent",
-          }
-        }
-      >
-        ܝ
-      </span>
+      ‍
     </span>
   </span>
   <span
@@ -365,15 +341,7 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
       }
       title="ܠ"
     >
-      <span
-        style={
-          Object {
-            "color": "transparent",
-          }
-        }
-      >
-        ܝ
-      </span>
+      ‍
       ܠ
       
     </span>
@@ -413,15 +381,7 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
     >
       
       ܡ
-      <span
-        style={
-          Object {
-            "color": "transparent",
-          }
-        }
-      >
-        ܝ
-      </span>
+      ‍
     </span>
   </span>
   <span
@@ -459,15 +419,7 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
     >
       
       ܢ
-      <span
-        style={
-          Object {
-            "color": "transparent",
-          }
-        }
-      >
-        ܝ
-      </span>
+      ‍
     </span>
   </span>
   <span
@@ -484,15 +436,7 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
       }
       title="ܢ"
     >
-      <span
-        style={
-          Object {
-            "color": "transparent",
-          }
-        }
-      >
-        ܝ
-      </span>
+      ‍
       ܢ
       
     </span>
@@ -701,15 +645,7 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
       }
       title="ܬ"
     >
-      <span
-        style={
-          Object {
-            "color": "transparent",
-          }
-        }
-      >
-        ܝ
-      </span>
+      ‍
       ܬ
       
     </span>

--- a/js/components/__tests__/__snapshots__/ManuscriptForm.test.js.snap
+++ b/js/components/__tests__/__snapshots__/ManuscriptForm.test.js.snap
@@ -470,25 +470,9 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
           }
           title="ܝ"
         >
-          <span
-            style={
-              Object {
-                "color": "transparent",
-              }
-            }
-          >
-            ܝ
-          </span>
+          ‍
           ܝ
-          <span
-            style={
-              Object {
-                "color": "transparent",
-              }
-            }
-          >
-            ܝ
-          </span>
+          ‍
         </span>
       </span>
       <span
@@ -526,15 +510,7 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
         >
           
           ܟ
-          <span
-            style={
-              Object {
-                "color": "transparent",
-              }
-            }
-          >
-            ܝ
-          </span>
+          ‍
         </span>
       </span>
       <span
@@ -589,15 +565,7 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
           }
           title="ܠ"
         >
-          <span
-            style={
-              Object {
-                "color": "transparent",
-              }
-            }
-          >
-            ܝ
-          </span>
+          ‍
           ܠ
           
         </span>
@@ -637,15 +605,7 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
         >
           
           ܡ
-          <span
-            style={
-              Object {
-                "color": "transparent",
-              }
-            }
-          >
-            ܝ
-          </span>
+          ‍
         </span>
       </span>
       <span
@@ -683,15 +643,7 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
         >
           
           ܢ
-          <span
-            style={
-              Object {
-                "color": "transparent",
-              }
-            }
-          >
-            ܝ
-          </span>
+          ‍
         </span>
       </span>
       <span
@@ -708,15 +660,7 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
           }
           title="ܢ"
         >
-          <span
-            style={
-              Object {
-                "color": "transparent",
-              }
-            }
-          >
-            ܝ
-          </span>
+          ‍
           ܢ
           
         </span>
@@ -925,15 +869,7 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
           }
           title="ܬ"
         >
-          <span
-            style={
-              Object {
-                "color": "transparent",
-              }
-            }
-          >
-            ܝ
-          </span>
+          ‍
           ܬ
           
         </span>

--- a/js/components/letters.json
+++ b/js/components/letters.json
@@ -89,8 +89,8 @@
     "is_script": true,
     "display": "ܝ",
     "script": "estrangela",
-    "leading_letter": "ܝ",
-    "trailing_letter": "ܝ"
+    "leading_letter": "‍",
+    "trailing_letter": "‍"
   },
   {
     "id": 49,
@@ -105,7 +105,7 @@
     "is_script": true,
     "display": "ܟ",
     "script": "estrangela",
-    "leading_letter": "ܝ"
+    "leading_letter": "‍"
   },
   {
     "id": 20,
@@ -127,7 +127,7 @@
     "is_script": true,
     "display": "ܠ",
     "script": "estrangela",
-    "trailing_letter": "ܝ"
+    "trailing_letter": "‍"
   },
   {
     "id": 23,
@@ -142,7 +142,7 @@
     "is_script": true,
     "display": "ܡ",
     "script": "estrangela",
-    "leading_letter": "ܝ"
+    "leading_letter": "‍"
   },
   {
     "id": 27,
@@ -157,7 +157,7 @@
     "is_script": true,
     "display": "ܢ",
     "script": "estrangela",
-    "leading_letter": "ܝ"
+    "leading_letter": "‍"
   },
   {
     "id": 30,
@@ -165,7 +165,7 @@
     "is_script": true,
     "display": "ܢ",
     "script": "estrangela",
-    "trailing_letter": "ܝ"
+    "trailing_letter": "‍"
   },
   {
     "id": 31,
@@ -243,7 +243,7 @@
     "is_script": true,
     "display": "ܬ",
     "script": "serto",
-    "trailing_letter": "ܝ"
+    "trailing_letter": "‍"
   },
   {
     "id": 42,


### PR DESCRIPTION
Following a suggestion from @simonwiles: instead of appending or prefixing a Syriac letter with a second, transparent letter to trick the browser into rendering final or medial letters correctly in the buttons and scriptchart row headers, use the special Unicode "zero-width joiner" character instead. This makes the widths of the letter buttons more consistent (because the joiner has zero-width, as advertised) but does not solve the problem of improper appearance of these letters in Chrome and Safari -- see https://github.com/sul-cidr/scriptchart/issues/54