### PR TITLE
Change label for= to htmlFor=

### DIFF
--- a/js/components/ManuscriptForm.js
+++ b/js/components/ManuscriptForm.js
@@ -162,7 +162,7 @@ class ManuscriptForm extends React.Component {
         </div>
 
         <div className={"field is-horizontal flex-row"}>
-          <label for="letterExamples" className={"control"}>
+          <label htmlFor="letterExamples" className={"control"}>
             Number of examples:{" "}
           </label>
           <div className={"select is-small"} style={{ marginLeft: "5px" }}>
@@ -182,7 +182,7 @@ class ManuscriptForm extends React.Component {
 
         <div className={"control"}>
           <p>Show letter images:</p>
-          <label for="showBinarized" className={"checkbox"}>
+          <label htmlFor="showBinarized" className={"checkbox"}>
             <input
               type="checkbox"
               name="showBinarized"
@@ -193,7 +193,7 @@ class ManuscriptForm extends React.Component {
             {" Trimmed |"}
           </label>
           <label
-            for="showCropped"
+            htmlFor="showCropped"
             className={"checkbox"}
             style={{ marginLeft: "8px" }}
           >
@@ -209,7 +209,7 @@ class ManuscriptForm extends React.Component {
         </div>
 
         <div className={"field is-horizontal flex-row"}>
-          <label for="imageSize" className={"control"}>
+          <label htmlFor="imageSize" className={"control"}>
             Image size:{" "}
           </label>
           <div className={"select is-small"} style={{ marginLeft: "5px" }}>
@@ -231,7 +231,7 @@ class ManuscriptForm extends React.Component {
           Letter in context:
           <ul>
             <li>
-              <label for="hoverContext" className={"radio"}>
+              <label htmlFor="hoverContext" className={"radio"}>
                 <input
                   type="radio"
                   value="hover"
@@ -243,7 +243,7 @@ class ManuscriptForm extends React.Component {
               </label>
             </li>
             <li>
-              <label for="clickContext" className={"radio"}>
+              <label htmlFor="clickContext" className={"radio"}>
                 <input
                   type="radio"
                   value="click"
@@ -258,7 +258,7 @@ class ManuscriptForm extends React.Component {
         </div>
 
         <div className={"field is-horizontal flex-row"}>
-          <label for="cropMargin" className={"control"}>
+          <label htmlFor="cropMargin" className={"control"}>
             Context size:{" "}
           </label>
           <div className={"select is-small"} style={{ marginLeft: "5px" }}>

--- a/js/components/ManuscriptMenu.js
+++ b/js/components/ManuscriptMenu.js
@@ -70,7 +70,7 @@ class ManuscriptMenu extends React.Component {
     return (
       <div className={"field"}>
         <div className={"control"} style={{ marginBottom: 5 }}>
-          <label for="selectedShelfmarks" className={"control"}>
+          <label htmlFor="selectedShelfmarks" className={"control"}>
             Select manuscripts:{" "}
           </label>
           <span className="button is-small" onClick={this.manuscriptsSelect}>
@@ -86,7 +86,7 @@ class ManuscriptMenu extends React.Component {
         </div>
         <div className={"control"}>
           <p>Order manuscripts by</p>
-          <label for="shelfmarkSort" className={"radio"}>
+          <label htmlFor="shelfmarkSort" className={"radio"}>
             <input
               type="radio"
               value="shelfmark"
@@ -96,7 +96,7 @@ class ManuscriptMenu extends React.Component {
             />{" "}
             Shelfmark |
           </label>
-          <label for="dateSort" className={"radio"}>
+          <label htmlFor="dateSort" className={"radio"}>
             <input
               type="radio"
               value="date"

--- a/js/components/__tests__/__snapshots__/App.test.js.snap
+++ b/js/components/__tests__/__snapshots__/App.test.js.snap
@@ -78,7 +78,7 @@ exports[`App test App should match snapshot 1`] = `
               >
                 <label
                   className="control"
-                  for="selectedShelfmarks"
+                  htmlFor="selectedShelfmarks"
                 >
                   Select manuscripts:
                    
@@ -120,7 +120,7 @@ exports[`App test App should match snapshot 1`] = `
                 </p>
                 <label
                   className="radio"
-                  for="shelfmarkSort"
+                  htmlFor="shelfmarkSort"
                 >
                   <input
                     checked={true}
@@ -134,7 +134,7 @@ exports[`App test App should match snapshot 1`] = `
                 </label>
                 <label
                   className="radio"
-                  for="dateSort"
+                  htmlFor="dateSort"
                 >
                   <input
                     checked={false}
@@ -910,7 +910,7 @@ exports[`App test App should match snapshot 1`] = `
             >
               <label
                 className="control"
-                for="letterExamples"
+                htmlFor="letterExamples"
               >
                 Number of examples:
                  
@@ -950,7 +950,7 @@ exports[`App test App should match snapshot 1`] = `
               </p>
               <label
                 className="checkbox"
-                for="showBinarized"
+                htmlFor="showBinarized"
               >
                 <input
                   checked={true}
@@ -963,7 +963,7 @@ exports[`App test App should match snapshot 1`] = `
               </label>
               <label
                 className="checkbox"
-                for="showCropped"
+                htmlFor="showCropped"
                 style={
                   Object {
                     "marginLeft": "8px",
@@ -985,7 +985,7 @@ exports[`App test App should match snapshot 1`] = `
             >
               <label
                 className="control"
-                for="imageSize"
+                htmlFor="imageSize"
               >
                 Image size:
                  
@@ -1025,7 +1025,7 @@ exports[`App test App should match snapshot 1`] = `
                 <li>
                   <label
                     className="radio"
-                    for="hoverContext"
+                    htmlFor="hoverContext"
                   >
                     <input
                       checked={true}
@@ -1041,7 +1041,7 @@ exports[`App test App should match snapshot 1`] = `
                 <li>
                   <label
                     className="radio"
-                    for="clickContext"
+                    htmlFor="clickContext"
                   >
                     <input
                       checked={false}
@@ -1061,7 +1061,7 @@ exports[`App test App should match snapshot 1`] = `
             >
               <label
                 className="control"
-                for="cropMargin"
+                htmlFor="cropMargin"
               >
                 Context size:
                  

--- a/js/components/__tests__/__snapshots__/ManuscriptForm.test.js.snap
+++ b/js/components/__tests__/__snapshots__/ManuscriptForm.test.js.snap
@@ -18,7 +18,7 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
     >
       <label
         className="control"
-        for="selectedShelfmarks"
+        htmlFor="selectedShelfmarks"
       >
         Select manuscripts:
          
@@ -174,7 +174,7 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
       </p>
       <label
         className="radio"
-        for="shelfmarkSort"
+        htmlFor="shelfmarkSort"
       >
         <input
           checked={true}
@@ -188,7 +188,7 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
       </label>
       <label
         className="radio"
-        for="dateSort"
+        htmlFor="dateSort"
       >
         <input
           checked={false}
@@ -964,7 +964,7 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
   >
     <label
       className="control"
-      for="letterExamples"
+      htmlFor="letterExamples"
     >
       Number of examples:
        
@@ -1004,7 +1004,7 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
     </p>
     <label
       className="checkbox"
-      for="showBinarized"
+      htmlFor="showBinarized"
     >
       <input
         checked={true}
@@ -1017,7 +1017,7 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
     </label>
     <label
       className="checkbox"
-      for="showCropped"
+      htmlFor="showCropped"
       style={
         Object {
           "marginLeft": "8px",
@@ -1039,7 +1039,7 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
   >
     <label
       className="control"
-      for="imageSize"
+      htmlFor="imageSize"
     >
       Image size:
        
@@ -1079,7 +1079,7 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
       <li>
         <label
           className="radio"
-          for="hoverContext"
+          htmlFor="hoverContext"
         >
           <input
             checked={true}
@@ -1095,7 +1095,7 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
       <li>
         <label
           className="radio"
-          for="clickContext"
+          htmlFor="clickContext"
         >
           <input
             checked={false}
@@ -1115,7 +1115,7 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
   >
     <label
       className="control"
-      for="cropMargin"
+      htmlFor="cropMargin"
     >
       Context size:
        

--- a/js/components/__tests__/__snapshots__/ManuscriptMenu.test.js.snap
+++ b/js/components/__tests__/__snapshots__/ManuscriptMenu.test.js.snap
@@ -14,7 +14,7 @@ exports[`ManuscriptMenu test ManuscriptMenu should match snapshot 1`] = `
   >
     <label
       className="control"
-      for="selectedShelfmarks"
+      htmlFor="selectedShelfmarks"
     >
       Select manuscripts:
        
@@ -169,7 +169,7 @@ exports[`ManuscriptMenu test ManuscriptMenu should match snapshot 1`] = `
     </p>
     <label
       className="radio"
-      for="shelfmarkSort"
+      htmlFor="shelfmarkSort"
     >
       <input
         checked={true}
@@ -183,7 +183,7 @@ exports[`ManuscriptMenu test ManuscriptMenu should match snapshot 1`] = `
     </label>
     <label
       className="radio"
-      for="dateSort"
+      htmlFor="dateSort"
     >
       <input
         checked={false}


### PR DESCRIPTION
Turns out that React doesn't like the semantic HTML `for` attribute within `<label>` elements and will throw an error in the console if it sees one (and then presumably not pass the relation on to assistive technologies that might use it). Instead, the `htmlFor` attribute must be used.