### PR TITLE
Add SVG versions of letters so that they display properly in Chrome and Safari

### DIFF
--- a/js/components/App.js
+++ b/js/components/App.js
@@ -18,7 +18,6 @@ import React, { Component } from "react";
 
 import "../../src/assets/syriac_fonts.css";
 import "./app.css";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 /* Loading fontawesome icons via React seems easier than doing
  * it via site-wide CSS */
@@ -27,18 +26,8 @@ import {
   faBookOpen,
   faTable,
   faImage
-  //faInfoCircle,
-  //faArrowRight,
-  //faArrowLeft
 } from "@fortawesome/free-solid-svg-icons";
-library.add(
-  faBookOpen,
-  faTable,
-  faImage
-  //faInfoCircle,
-  //faArrowRight,
-  //faArrowLeft
-);
+library.add(faBookOpen, faTable, faImage);
 
 /* The entire app needs to be wrapped in the drag-and-drop context */
 import HTML5Backend from "react-dnd-html5-backend";

--- a/js/components/ChartAccordion.js
+++ b/js/components/ChartAccordion.js
@@ -72,6 +72,7 @@ class ChartAccordion extends React.Component {
                   buttonClass="button is-outlined"
                   onHiddenChange={this.props.onHiddenChange}
                   letter={<SyriacLetter id={ltid} />}
+                  isButton={true}
                 />
               ))}
             </div>

--- a/js/components/DragTable.js
+++ b/js/components/DragTable.js
@@ -19,6 +19,12 @@ import * as Sticky from "reactabular-sticky";
 class DragTable extends React.Component {
   constructor(props) {
     super(props);
+
+    this.onScrollFromNative = this.onScrollFromNative.bind(this);
+  }
+
+  onScrollFromNative(e) {
+    this.tableHeader.scrollLeft = e.target.scrollLeft;
   }
 
   render() {

--- a/js/components/DragTable.js
+++ b/js/components/DragTable.js
@@ -20,18 +20,12 @@ class DragTable extends React.Component {
   constructor(props) {
     super(props);
 
-    this.onScrollFromNative = this.onScrollFromNative.bind(this);
+    //this.onScrollFromNative = this.onScrollFromNative.bind(this);
   }
 
-  onScrollFromNative(e) {
-    // just demo to reproduce issue of native horizontal scrollbar
-    // We should not intercept the native onScroll event actually
-    console.log(
-      "onScrollFromNative called => e.target.scrollLeft=",
-      e.target.scrollLeft
-    );
+  /*onScrollFromNative(e) {
     this.tableHeader.scrollLeft = e.target.scrollLeft;
-  }
+  }*/
 
   render() {
     console.log("Rendering DragTable");

--- a/js/components/DragTable.js
+++ b/js/components/DragTable.js
@@ -19,13 +19,7 @@ import * as Sticky from "reactabular-sticky";
 class DragTable extends React.Component {
   constructor(props) {
     super(props);
-
-    //this.onScrollFromNative = this.onScrollFromNative.bind(this);
   }
-
-  /*onScrollFromNative(e) {
-    this.tableHeader.scrollLeft = e.target.scrollLeft;
-  }*/
 
   render() {
     console.log("Rendering DragTable");

--- a/js/components/LetterButton.js
+++ b/js/components/LetterButton.js
@@ -10,9 +10,12 @@ import React from "react";
  * letters grid).
  */
 
+import SyriacLetter from "./SyriacLetter";
+
 class LetterButton extends React.Component {
   constructor(props) {
     super(props);
+
     this.onLetterClicked = this.onLetterClicked.bind(this);
   }
   onLetterClicked() {
@@ -29,7 +32,7 @@ class LetterButton extends React.Component {
   render() {
     return (
       <span className={this.props.buttonClass} onClick={this.onLetterClicked}>
-        {this.props.letter}
+        <SyriacLetter id={this.props.letterID} clicked={this.props.clicked} />
       </span>
     );
   }

--- a/js/components/LetterButton.js
+++ b/js/components/LetterButton.js
@@ -32,7 +32,11 @@ class LetterButton extends React.Component {
   render() {
     return (
       <span className={this.props.buttonClass} onClick={this.onLetterClicked}>
-        <SyriacLetter id={this.props.letterID} clicked={this.props.clicked} />
+        <SyriacLetter
+          id={this.props.letterID}
+          clicked={this.props.clicked}
+          isButton={this.props.isButton}
+        />
       </span>
     );
   }

--- a/js/components/LettersLoader.js
+++ b/js/components/LettersLoader.js
@@ -10,8 +10,6 @@ import React from "react";
 
 import LetterButton from "./LetterButton";
 
-import SyriacLetter from "./SyriacLetter";
-
 import letters from "./letters.json";
 
 class LettersLoader extends React.Component {
@@ -30,8 +28,10 @@ class LettersLoader extends React.Component {
 
     let buttons = letters.map(lt => {
       let letterClass = "button is-outlined";
+      let isClicked = false;
       if (this.props.selectedLetters.findIndex(l => l.id == lt.id) >= 0) {
         letterClass = "button is-success";
+        isClicked = true;
       }
       return (
         <LetterButton
@@ -39,7 +39,7 @@ class LettersLoader extends React.Component {
           letterID={lt.id}
           onLetterClick={this.buttonClick}
           buttonClass={letterClass}
-          letter={<SyriacLetter id={lt.id} />}
+          clicked={isClicked}
         />
       );
     });

--- a/js/components/LettersLoader.js
+++ b/js/components/LettersLoader.js
@@ -40,6 +40,7 @@ class LettersLoader extends React.Component {
           onLetterClick={this.buttonClick}
           buttonClass={letterClass}
           clicked={isClicked}
+          isButton={true}
         />
       );
     });

--- a/js/components/ScriptChart.js
+++ b/js/components/ScriptChart.js
@@ -89,7 +89,7 @@ class ScriptChart extends React.Component {
       let row = {
         id: i + 2,
         ltid: ltID,
-        letter: <SyriacLetter key={ltID} id={ltID} />,
+        letter: <SyriacLetter key={ltID} id={ltID} isButton={false}/>,
         visible: !this.props.hiddenLetters.includes(ltID)
       };
 

--- a/js/components/SyriacLetter.js
+++ b/js/components/SyriacLetter.js
@@ -31,7 +31,8 @@ class SyriacLetter extends React.Component {
         <div title={letter.letter} style={{ verticalAlign: "center" }}>
           <img
             className={
-              "button-image " + (this.props.clicked ? "button-clicked" : "")
+              (this.props.isButton ? "button-svg " : "chart-svg ") +
+              (this.props.clicked ? "button-clicked" : "")
             }
             src={"/scriptchart/assets/font_glyphs/" + letter.glyph_file}
           />
@@ -49,11 +50,11 @@ class SyriacLetter extends React.Component {
       letter_display = (
         <div
           title={letter.letter}
+          className={
+            (this.props.isButton ? "button-letter" : "chart-letter")
+          }
           style={{
-            direction: "rtl",
-            fontSize: "2em",
-            fontFamily: font,
-            verticalAlign: "center"
+            fontFamily: font
           }}
         >
           {lettertext}

--- a/js/components/SyriacLetter.js
+++ b/js/components/SyriacLetter.js
@@ -13,49 +13,55 @@ import letters from "./letters.json";
 class SyriacLetter extends React.Component {
   constructor(props) {
     super(props);
+  }
 
-    this.letter = letters.find(lt => lt.id == this.props.id);
-    this.lettertext = this.letter.display;
+  render() {
+    let letter = letters.find(lt => lt.id == this.props.id);
 
-    if (this.letter.hasOwnProperty("glyph_file")) {
-      // XXX Consider setting style {filter: "invert(1)"} when selected
-      this.display = (
-        <div title={this.display} style={{ verticalAlign: "center" }}>
+    if (letter === undefined) {
+      return <div />;
+    }
+
+    let lettertext = letter.display;
+
+    let letter_display = <div>lettertext</div>;
+
+    if (letter.hasOwnProperty("glyph_file")) {
+      letter_display = (
+        <div title={letter.letter} style={{ verticalAlign: "center" }}>
           <img
-            className={"button-image"}
-            src={"/scriptchart/assets/font_glyphs/" + this.letter.glyph_file}
-            style={{ height: "2em", verticalAlign: "bottom" }}
+            className={
+              "button-image " + (this.props.clicked ? "button-clicked" : "")
+            }
+            src={"/scriptchart/assets/font_glyphs/" + letter.glyph_file}
           />
         </div>
       );
     } else {
-      this.script = this.letter.script;
+      let script = letter.script;
       /* Fonts provided by https://sedra.bethmardutho.org/about/fonts */
-      if (this.script == "serto") {
-        this.font = "SertoJerusalem";
-      } else if (this.script == "estrangela") {
-        this.font = "EstrangeloEdessa";
-      } else {
-        this.font = "sans-serif";
+      let font = "sans-serif";
+      if (script == "serto") {
+        font = "SertoJerusalem";
+      } else if (script == "estrangela") {
+        font = "EstrangeloEdessa";
       }
-      this.display = (
+      letter_display = (
         <div
-          title={this.display}
+          title={letter.letter}
           style={{
             direction: "rtl",
             fontSize: "2em",
-            fontFamily: this.font,
+            fontFamily: font,
             verticalAlign: "center"
           }}
         >
-          {this.lettertext}
+          {lettertext}
         </div>
       );
     }
-  }
 
-  render() {
-    return this.display;
+    return letter_display;
   }
 }
 

--- a/js/components/SyriacLetter.js
+++ b/js/components/SyriacLetter.js
@@ -24,7 +24,7 @@ class SyriacLetter extends React.Component {
           <img
             className={"button-image"}
             src={"/scriptchart/assets/font_glyphs/" + this.letter.glyph_file}
-            style={{ height: "2rem" }}
+            style={{ height: "2em", verticalAlign: "bottom" }}
           />
         </div>
       );

--- a/js/components/SyriacLetter.js
+++ b/js/components/SyriacLetter.js
@@ -6,6 +6,8 @@ import React from "react";
  * and not available via the backend REST API.
  */
 
+import "./index.css";
+
 import letters from "./letters.json";
 
 class SyriacLetter extends React.Component {
@@ -13,11 +15,20 @@ class SyriacLetter extends React.Component {
     super(props);
 
     this.letter = letters.find(lt => lt.id == this.props.id);
-    this.trailing = "";
-    this.leading = "";
+    this.lettertext = this.letter.display;
 
-    if (this.letter !== undefined) {
-      this.display = this.letter.display;
+    if (this.letter.hasOwnProperty("glyph_file")) {
+      // XXX Consider setting style {filter: "invert(1)"} when selected
+      this.display = (
+        <div title={this.display} style={{ verticalAlign: "center" }}>
+          <img
+            className={"button-image"}
+            src={"/scriptchart/assets/font_glyphs/" + this.letter.glyph_file}
+            style={{ height: "2rem" }}
+          />
+        </div>
+      );
+    } else {
       this.script = this.letter.script;
       /* Fonts provided by https://sedra.bethmardutho.org/about/fonts */
       if (this.script == "serto") {
@@ -27,37 +38,24 @@ class SyriacLetter extends React.Component {
       } else {
         this.font = "sans-serif";
       }
-      /* Prefix final forms (and wrap medial forms) via transparent
-       * "spacer" letters to make them display properly. Note that
-       * positions are read from right to left.
-       * XXX This trick may only work in Firefox :-(
-       * */
-      if (this.letter.hasOwnProperty("trailing_letter")) {
-        this.trailing = this.letter.trailing_letter;
-      }
-      if (this.letter.hasOwnProperty("leading_letter")) {
-        this.leading = this.letter.leading_letter;
-      }
-    } else {
-      if (this.props.hasOwnProperty("letter")) {
-        this.display = this.props.letter;
-      } else {
-        this.display = this.props.id;
-      }
+      this.display = (
+        <div
+          title={this.display}
+          style={{
+            direction: "rtl",
+            fontSize: "2em",
+            fontFamily: this.font,
+            verticalAlign: "center"
+          }}
+        >
+          {this.lettertext}
+        </div>
+      );
     }
   }
 
   render() {
-    return (
-      <span
-        title={this.display}
-        style={{ direction: "rtl", fontSize: "2em", fontFamily: this.font }}
-      >
-        {this.trailing}
-        {this.display}
-        {this.leading}
-      </span>
-    );
+    return this.display;
   }
 }
 

--- a/js/components/__tests__/__snapshots__/App.test.js.snap
+++ b/js/components/__tests__/__snapshots__/App.test.js.snap
@@ -179,12 +179,10 @@ exports[`App test App should match snapshot 1`] = `
                   onClick={[Function]}
                 >
                   <div
+                    className="button-letter"
                     style={
                       Object {
-                        "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
-                        "fontSize": "2em",
-                        "verticalAlign": "center",
                       }
                     }
                     title="Alaph (Angular)"
@@ -197,12 +195,10 @@ exports[`App test App should match snapshot 1`] = `
                   onClick={[Function]}
                 >
                   <div
+                    className="button-letter"
                     style={
                       Object {
-                        "direction": "rtl",
                         "fontFamily": "SertoJerusalem",
-                        "fontSize": "2em",
-                        "verticalAlign": "center",
                       }
                     }
                     title="Alaph (Round)"
@@ -215,12 +211,10 @@ exports[`App test App should match snapshot 1`] = `
                   onClick={[Function]}
                 >
                   <div
+                    className="button-letter"
                     style={
                       Object {
-                        "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
-                        "fontSize": "2em",
-                        "verticalAlign": "center",
                       }
                     }
                     title="Beth"
@@ -233,12 +227,10 @@ exports[`App test App should match snapshot 1`] = `
                   onClick={[Function]}
                 >
                   <div
+                    className="button-letter"
                     style={
                       Object {
-                        "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
-                        "fontSize": "2em",
-                        "verticalAlign": "center",
                       }
                     }
                     title="Gamal"
@@ -251,12 +243,10 @@ exports[`App test App should match snapshot 1`] = `
                   onClick={[Function]}
                 >
                   <div
+                    className="button-letter"
                     style={
                       Object {
-                        "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
-                        "fontSize": "2em",
-                        "verticalAlign": "center",
                       }
                     }
                     title="Dalath (Angular)"
@@ -269,12 +259,10 @@ exports[`App test App should match snapshot 1`] = `
                   onClick={[Function]}
                 >
                   <div
+                    className="button-letter"
                     style={
                       Object {
-                        "direction": "rtl",
                         "fontFamily": "SertoJerusalem",
-                        "fontSize": "2em",
-                        "verticalAlign": "center",
                       }
                     }
                     title="Dalath (Round)"
@@ -287,12 +275,10 @@ exports[`App test App should match snapshot 1`] = `
                   onClick={[Function]}
                 >
                   <div
+                    className="button-letter"
                     style={
                       Object {
-                        "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
-                        "fontSize": "2em",
-                        "verticalAlign": "center",
                       }
                     }
                     title="He (Angular)"
@@ -305,12 +291,10 @@ exports[`App test App should match snapshot 1`] = `
                   onClick={[Function]}
                 >
                   <div
+                    className="button-letter"
                     style={
                       Object {
-                        "direction": "rtl",
                         "fontFamily": "SertoJerusalem",
-                        "fontSize": "2em",
-                        "verticalAlign": "center",
                       }
                     }
                     title="He (Round)"
@@ -323,12 +307,10 @@ exports[`App test App should match snapshot 1`] = `
                   onClick={[Function]}
                 >
                   <div
+                    className="button-letter"
                     style={
                       Object {
-                        "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
-                        "fontSize": "2em",
-                        "verticalAlign": "center",
                       }
                     }
                     title="Waw"
@@ -341,12 +323,10 @@ exports[`App test App should match snapshot 1`] = `
                   onClick={[Function]}
                 >
                   <div
+                    className="button-letter"
                     style={
                       Object {
-                        "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
-                        "fontSize": "2em",
-                        "verticalAlign": "center",
                       }
                     }
                     title="Zain"
@@ -359,12 +339,10 @@ exports[`App test App should match snapshot 1`] = `
                   onClick={[Function]}
                 >
                   <div
+                    className="button-letter"
                     style={
                       Object {
-                        "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
-                        "fontSize": "2em",
-                        "verticalAlign": "center",
                       }
                     }
                     title="Heth"
@@ -377,12 +355,10 @@ exports[`App test App should match snapshot 1`] = `
                   onClick={[Function]}
                 >
                   <div
+                    className="button-letter"
                     style={
                       Object {
-                        "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
-                        "fontSize": "2em",
-                        "verticalAlign": "center",
                       }
                     }
                     title="Teth"
@@ -403,7 +379,7 @@ exports[`App test App should match snapshot 1`] = `
                     title="Yudh (Connected)"
                   >
                     <img
-                      className="button-image "
+                      className="button-svg "
                       src="/scriptchart/assets/font_glyphs/yudh_connected.svg"
                     />
                   </div>
@@ -413,12 +389,10 @@ exports[`App test App should match snapshot 1`] = `
                   onClick={[Function]}
                 >
                   <div
+                    className="button-letter"
                     style={
                       Object {
-                        "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
-                        "fontSize": "2em",
-                        "verticalAlign": "center",
                       }
                     }
                     title="Yudh (Stand-alone)"
@@ -439,7 +413,7 @@ exports[`App test App should match snapshot 1`] = `
                     title="Kaph"
                   >
                     <img
-                      className="button-image "
+                      className="button-svg "
                       src="/scriptchart/assets/font_glyphs/kaph.svg"
                     />
                   </div>
@@ -449,12 +423,10 @@ exports[`App test App should match snapshot 1`] = `
                   onClick={[Function]}
                 >
                   <div
+                    className="button-letter"
                     style={
                       Object {
-                        "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
-                        "fontSize": "2em",
-                        "verticalAlign": "center",
                       }
                     }
                     title="Kaph (Final)"
@@ -467,12 +439,10 @@ exports[`App test App should match snapshot 1`] = `
                   onClick={[Function]}
                 >
                   <div
+                    className="button-letter"
                     style={
                       Object {
-                        "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
-                        "fontSize": "2em",
-                        "verticalAlign": "center",
                       }
                     }
                     title="Lamadh (Final, open)"
@@ -493,7 +463,7 @@ exports[`App test App should match snapshot 1`] = `
                     title="Lamadh"
                   >
                     <img
-                      className="button-image "
+                      className="button-svg "
                       src="/scriptchart/assets/font_glyphs/lamadh.svg"
                     />
                   </div>
@@ -503,12 +473,10 @@ exports[`App test App should match snapshot 1`] = `
                   onClick={[Function]}
                 >
                   <div
+                    className="button-letter"
                     style={
                       Object {
-                        "direction": "rtl",
                         "fontFamily": "SertoJerusalem",
-                        "fontSize": "2em",
-                        "verticalAlign": "center",
                       }
                     }
                     title="Lamadh (Final, closed)"
@@ -529,7 +497,7 @@ exports[`App test App should match snapshot 1`] = `
                     title="Mim"
                   >
                     <img
-                      className="button-image "
+                      className="button-svg "
                       src="/scriptchart/assets/font_glyphs/mim.svg"
                     />
                   </div>
@@ -539,12 +507,10 @@ exports[`App test App should match snapshot 1`] = `
                   onClick={[Function]}
                 >
                   <div
+                    className="button-letter"
                     style={
                       Object {
-                        "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
-                        "fontSize": "2em",
-                        "verticalAlign": "center",
                       }
                     }
                     title="Mim (Final)"
@@ -565,7 +531,7 @@ exports[`App test App should match snapshot 1`] = `
                     title="Nun"
                   >
                     <img
-                      className="button-image "
+                      className="button-svg "
                       src="/scriptchart/assets/font_glyphs/nun.svg"
                     />
                   </div>
@@ -583,7 +549,7 @@ exports[`App test App should match snapshot 1`] = `
                     title="Nun (Final, connected)"
                   >
                     <img
-                      className="button-image "
+                      className="button-svg "
                       src="/scriptchart/assets/font_glyphs/nun_final.svg"
                     />
                   </div>
@@ -593,12 +559,10 @@ exports[`App test App should match snapshot 1`] = `
                   onClick={[Function]}
                 >
                   <div
+                    className="button-letter"
                     style={
                       Object {
-                        "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
-                        "fontSize": "2em",
-                        "verticalAlign": "center",
                       }
                     }
                     title="Nun (Final, unconnected)"
@@ -611,12 +575,10 @@ exports[`App test App should match snapshot 1`] = `
                   onClick={[Function]}
                 >
                   <div
+                    className="button-letter"
                     style={
                       Object {
-                        "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
-                        "fontSize": "2em",
-                        "verticalAlign": "center",
                       }
                     }
                     title="Semkath"
@@ -629,12 +591,10 @@ exports[`App test App should match snapshot 1`] = `
                   onClick={[Function]}
                 >
                   <div
+                    className="button-letter"
                     style={
                       Object {
-                        "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
-                        "fontSize": "2em",
-                        "verticalAlign": "center",
                       }
                     }
                     title="Ayin"
@@ -647,12 +607,10 @@ exports[`App test App should match snapshot 1`] = `
                   onClick={[Function]}
                 >
                   <div
+                    className="button-letter"
                     style={
                       Object {
-                        "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
-                        "fontSize": "2em",
-                        "verticalAlign": "center",
                       }
                     }
                     title="Pe"
@@ -665,12 +623,10 @@ exports[`App test App should match snapshot 1`] = `
                   onClick={[Function]}
                 >
                   <div
+                    className="button-letter"
                     style={
                       Object {
-                        "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
-                        "fontSize": "2em",
-                        "verticalAlign": "center",
                       }
                     }
                     title="Sadhe"
@@ -683,12 +639,10 @@ exports[`App test App should match snapshot 1`] = `
                   onClick={[Function]}
                 >
                   <div
+                    className="button-letter"
                     style={
                       Object {
-                        "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
-                        "fontSize": "2em",
-                        "verticalAlign": "center",
                       }
                     }
                     title="Qaph"
@@ -701,12 +655,10 @@ exports[`App test App should match snapshot 1`] = `
                   onClick={[Function]}
                 >
                   <div
+                    className="button-letter"
                     style={
                       Object {
-                        "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
-                        "fontSize": "2em",
-                        "verticalAlign": "center",
                       }
                     }
                     title="Rish (Angular)"
@@ -719,12 +671,10 @@ exports[`App test App should match snapshot 1`] = `
                   onClick={[Function]}
                 >
                   <div
+                    className="button-letter"
                     style={
                       Object {
-                        "direction": "rtl",
                         "fontFamily": "SertoJerusalem",
-                        "fontSize": "2em",
-                        "verticalAlign": "center",
                       }
                     }
                     title="Rish (Round)"
@@ -737,12 +687,10 @@ exports[`App test App should match snapshot 1`] = `
                   onClick={[Function]}
                 >
                   <div
+                    className="button-letter"
                     style={
                       Object {
-                        "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
-                        "fontSize": "2em",
-                        "verticalAlign": "center",
                       }
                     }
                     title="Shin"
@@ -755,12 +703,10 @@ exports[`App test App should match snapshot 1`] = `
                   onClick={[Function]}
                 >
                   <div
+                    className="button-letter"
                     style={
                       Object {
-                        "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
-                        "fontSize": "2em",
-                        "verticalAlign": "center",
                       }
                     }
                     title="Taw (Looped)"
@@ -781,7 +727,7 @@ exports[`App test App should match snapshot 1`] = `
                     title="Taw (Triangular)"
                   >
                     <img
-                      className="button-image "
+                      className="button-svg "
                       src="/scriptchart/assets/font_glyphs/taw_triangular.svg"
                     />
                   </div>
@@ -791,12 +737,10 @@ exports[`App test App should match snapshot 1`] = `
                   onClick={[Function]}
                 >
                   <div
+                    className="button-letter"
                     style={
                       Object {
-                        "direction": "rtl",
                         "fontFamily": "SertoJerusalem",
-                        "fontSize": "2em",
-                        "verticalAlign": "center",
                       }
                     }
                     title="Taw (L-shaped)"

--- a/js/components/__tests__/__snapshots__/App.test.js.snap
+++ b/js/components/__tests__/__snapshots__/App.test.js.snap
@@ -178,666 +178,631 @@ exports[`App test App should match snapshot 1`] = `
                   className="button is-outlined"
                   onClick={[Function]}
                 >
-                  <span
+                  <div
                     style={
                       Object {
                         "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
                         "fontSize": "2em",
+                        "verticalAlign": "center",
                       }
                     }
-                    title="ܐ"
+                    title="Alaph (Angular)"
                   >
-                    
                     ܐ
-                    
-                  </span>
+                  </div>
                 </span>
                 <span
                   className="button is-outlined"
                   onClick={[Function]}
                 >
-                  <span
+                  <div
                     style={
                       Object {
                         "direction": "rtl",
                         "fontFamily": "SertoJerusalem",
                         "fontSize": "2em",
+                        "verticalAlign": "center",
                       }
                     }
-                    title="ܐ"
+                    title="Alaph (Round)"
                   >
-                    
                     ܐ
-                    
-                  </span>
+                  </div>
                 </span>
                 <span
                   className="button is-outlined"
                   onClick={[Function]}
                 >
-                  <span
+                  <div
                     style={
                       Object {
                         "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
                         "fontSize": "2em",
+                        "verticalAlign": "center",
                       }
                     }
-                    title="ܒ"
+                    title="Beth"
                   >
-                    
                     ܒ
-                    
-                  </span>
+                  </div>
                 </span>
                 <span
                   className="button is-outlined"
                   onClick={[Function]}
                 >
-                  <span
+                  <div
                     style={
                       Object {
                         "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
                         "fontSize": "2em",
+                        "verticalAlign": "center",
                       }
                     }
-                    title="ܓ"
+                    title="Gamal"
                   >
-                    
                     ܓ
-                    
-                  </span>
+                  </div>
                 </span>
                 <span
                   className="button is-outlined"
                   onClick={[Function]}
                 >
-                  <span
+                  <div
                     style={
                       Object {
                         "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
                         "fontSize": "2em",
+                        "verticalAlign": "center",
                       }
                     }
-                    title="ܕ"
+                    title="Dalath (Angular)"
                   >
-                    
                     ܕ
-                    
-                  </span>
+                  </div>
                 </span>
                 <span
                   className="button is-outlined"
                   onClick={[Function]}
                 >
-                  <span
+                  <div
                     style={
                       Object {
                         "direction": "rtl",
                         "fontFamily": "SertoJerusalem",
                         "fontSize": "2em",
+                        "verticalAlign": "center",
                       }
                     }
-                    title="ܕ"
+                    title="Dalath (Round)"
                   >
-                    
                     ܕ
-                    
-                  </span>
+                  </div>
                 </span>
                 <span
                   className="button is-outlined"
                   onClick={[Function]}
                 >
-                  <span
+                  <div
                     style={
                       Object {
                         "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
                         "fontSize": "2em",
+                        "verticalAlign": "center",
                       }
                     }
-                    title="ܗ"
+                    title="He (Angular)"
                   >
-                    
                     ܗ
-                    
-                  </span>
+                  </div>
                 </span>
                 <span
                   className="button is-outlined"
                   onClick={[Function]}
                 >
-                  <span
+                  <div
                     style={
                       Object {
                         "direction": "rtl",
                         "fontFamily": "SertoJerusalem",
                         "fontSize": "2em",
+                        "verticalAlign": "center",
                       }
                     }
-                    title="ܗ"
+                    title="He (Round)"
                   >
-                    
                     ܗ
-                    
-                  </span>
+                  </div>
                 </span>
                 <span
                   className="button is-outlined"
                   onClick={[Function]}
                 >
-                  <span
+                  <div
                     style={
                       Object {
                         "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
                         "fontSize": "2em",
+                        "verticalAlign": "center",
                       }
                     }
-                    title="ܘ"
+                    title="Waw"
                   >
-                    
                     ܘ
-                    
-                  </span>
+                  </div>
                 </span>
                 <span
                   className="button is-outlined"
                   onClick={[Function]}
                 >
-                  <span
+                  <div
                     style={
                       Object {
                         "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
                         "fontSize": "2em",
+                        "verticalAlign": "center",
                       }
                     }
-                    title="ܙ"
+                    title="Zain"
                   >
-                    
                     ܙ
-                    
-                  </span>
+                  </div>
                 </span>
                 <span
                   className="button is-outlined"
                   onClick={[Function]}
                 >
-                  <span
+                  <div
                     style={
                       Object {
                         "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
                         "fontSize": "2em",
+                        "verticalAlign": "center",
                       }
                     }
-                    title="ܚ"
+                    title="Heth"
                   >
-                    
                     ܚ
-                    
-                  </span>
+                  </div>
                 </span>
                 <span
                   className="button is-outlined"
                   onClick={[Function]}
                 >
-                  <span
+                  <div
                     style={
                       Object {
                         "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
                         "fontSize": "2em",
+                        "verticalAlign": "center",
                       }
                     }
-                    title="ܛ"
+                    title="Teth"
                   >
-                    
                     ܛ
-                    
-                  </span>
+                  </div>
                 </span>
                 <span
                   className="button is-outlined"
                   onClick={[Function]}
                 >
-                  <span
+                  <div
+                    style={
+                      Object {
+                        "verticalAlign": "center",
+                      }
+                    }
+                    title="Yudh (Connected)"
+                  >
+                    <img
+                      className="button-image "
+                      src="/scriptchart/assets/font_glyphs/yudh_connected.svg"
+                    />
+                  </div>
+                </span>
+                <span
+                  className="button is-outlined"
+                  onClick={[Function]}
+                >
+                  <div
                     style={
                       Object {
                         "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
                         "fontSize": "2em",
+                        "verticalAlign": "center",
                       }
                     }
-                    title="ܝ"
+                    title="Yudh (Stand-alone)"
                   >
-                    ‍
                     ܝ
-                    ‍
-                  </span>
+                  </div>
                 </span>
                 <span
                   className="button is-outlined"
                   onClick={[Function]}
                 >
-                  <span
+                  <div
                     style={
                       Object {
-                        "direction": "rtl",
-                        "fontFamily": "EstrangeloEdessa",
-                        "fontSize": "2em",
+                        "verticalAlign": "center",
                       }
                     }
-                    title="ܝ"
+                    title="Kaph"
                   >
-                    
-                    ܝ
-                    
-                  </span>
+                    <img
+                      className="button-image "
+                      src="/scriptchart/assets/font_glyphs/kaph.svg"
+                    />
+                  </div>
                 </span>
                 <span
                   className="button is-outlined"
                   onClick={[Function]}
                 >
-                  <span
+                  <div
                     style={
                       Object {
                         "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
                         "fontSize": "2em",
+                        "verticalAlign": "center",
                       }
                     }
-                    title="ܟ"
+                    title="Kaph (Final)"
                   >
-                    
                     ܟ
-                    ‍
-                  </span>
+                  </div>
                 </span>
                 <span
                   className="button is-outlined"
                   onClick={[Function]}
                 >
-                  <span
+                  <div
                     style={
                       Object {
                         "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
                         "fontSize": "2em",
+                        "verticalAlign": "center",
                       }
                     }
-                    title="ܟ"
+                    title="Lamadh (Final, open)"
                   >
-                    
-                    ܟ
-                    
-                  </span>
-                </span>
-                <span
-                  className="button is-outlined"
-                  onClick={[Function]}
-                >
-                  <span
-                    style={
-                      Object {
-                        "direction": "rtl",
-                        "fontFamily": "EstrangeloEdessa",
-                        "fontSize": "2em",
-                      }
-                    }
-                    title="ܠ"
-                  >
-                    
                     ܠ
-                    
-                  </span>
+                  </div>
                 </span>
                 <span
                   className="button is-outlined"
                   onClick={[Function]}
                 >
-                  <span
+                  <div
                     style={
                       Object {
-                        "direction": "rtl",
-                        "fontFamily": "EstrangeloEdessa",
-                        "fontSize": "2em",
+                        "verticalAlign": "center",
                       }
                     }
-                    title="ܠ"
+                    title="Lamadh"
                   >
-                    ‍
-                    ܠ
-                    
-                  </span>
+                    <img
+                      className="button-image "
+                      src="/scriptchart/assets/font_glyphs/lamadh.svg"
+                    />
+                  </div>
                 </span>
                 <span
                   className="button is-outlined"
                   onClick={[Function]}
                 >
-                  <span
+                  <div
                     style={
                       Object {
                         "direction": "rtl",
                         "fontFamily": "SertoJerusalem",
                         "fontSize": "2em",
+                        "verticalAlign": "center",
                       }
                     }
-                    title="ܠ"
+                    title="Lamadh (Final, closed)"
                   >
-                    
                     ܠ
-                    
-                  </span>
+                  </div>
                 </span>
                 <span
                   className="button is-outlined"
                   onClick={[Function]}
                 >
-                  <span
+                  <div
+                    style={
+                      Object {
+                        "verticalAlign": "center",
+                      }
+                    }
+                    title="Mim"
+                  >
+                    <img
+                      className="button-image "
+                      src="/scriptchart/assets/font_glyphs/mim.svg"
+                    />
+                  </div>
+                </span>
+                <span
+                  className="button is-outlined"
+                  onClick={[Function]}
+                >
+                  <div
                     style={
                       Object {
                         "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
                         "fontSize": "2em",
+                        "verticalAlign": "center",
                       }
                     }
-                    title="ܡ"
+                    title="Mim (Final)"
                   >
-                    
                     ܡ
-                    ‍
-                  </span>
+                  </div>
                 </span>
                 <span
                   className="button is-outlined"
                   onClick={[Function]}
                 >
-                  <span
+                  <div
                     style={
                       Object {
-                        "direction": "rtl",
-                        "fontFamily": "EstrangeloEdessa",
-                        "fontSize": "2em",
+                        "verticalAlign": "center",
                       }
                     }
-                    title="ܡ"
+                    title="Nun"
                   >
-                    
-                    ܡ
-                    
-                  </span>
+                    <img
+                      className="button-image "
+                      src="/scriptchart/assets/font_glyphs/nun.svg"
+                    />
+                  </div>
                 </span>
                 <span
                   className="button is-outlined"
                   onClick={[Function]}
                 >
-                  <span
+                  <div
+                    style={
+                      Object {
+                        "verticalAlign": "center",
+                      }
+                    }
+                    title="Nun (Final, connected)"
+                  >
+                    <img
+                      className="button-image "
+                      src="/scriptchart/assets/font_glyphs/nun_final.svg"
+                    />
+                  </div>
+                </span>
+                <span
+                  className="button is-outlined"
+                  onClick={[Function]}
+                >
+                  <div
                     style={
                       Object {
                         "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
                         "fontSize": "2em",
+                        "verticalAlign": "center",
                       }
                     }
-                    title="ܢ"
+                    title="Nun (Final, unconnected)"
                   >
-                    
                     ܢ
-                    ‍
-                  </span>
+                  </div>
                 </span>
                 <span
                   className="button is-outlined"
                   onClick={[Function]}
                 >
-                  <span
+                  <div
                     style={
                       Object {
                         "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
                         "fontSize": "2em",
+                        "verticalAlign": "center",
                       }
                     }
-                    title="ܢ"
+                    title="Semkath"
                   >
-                    ‍
-                    ܢ
-                    
-                  </span>
-                </span>
-                <span
-                  className="button is-outlined"
-                  onClick={[Function]}
-                >
-                  <span
-                    style={
-                      Object {
-                        "direction": "rtl",
-                        "fontFamily": "EstrangeloEdessa",
-                        "fontSize": "2em",
-                      }
-                    }
-                    title="ܢ"
-                  >
-                    
-                    ܢ
-                    
-                  </span>
-                </span>
-                <span
-                  className="button is-outlined"
-                  onClick={[Function]}
-                >
-                  <span
-                    style={
-                      Object {
-                        "direction": "rtl",
-                        "fontFamily": "EstrangeloEdessa",
-                        "fontSize": "2em",
-                      }
-                    }
-                    title="ܣ"
-                  >
-                    
                     ܣ
-                    
-                  </span>
+                  </div>
                 </span>
                 <span
                   className="button is-outlined"
                   onClick={[Function]}
                 >
-                  <span
+                  <div
                     style={
                       Object {
                         "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
                         "fontSize": "2em",
+                        "verticalAlign": "center",
                       }
                     }
-                    title="ܥ"
+                    title="Ayin"
                   >
-                    
                     ܥ
-                    
-                  </span>
+                  </div>
                 </span>
                 <span
                   className="button is-outlined"
                   onClick={[Function]}
                 >
-                  <span
+                  <div
                     style={
                       Object {
                         "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
                         "fontSize": "2em",
+                        "verticalAlign": "center",
                       }
                     }
-                    title="ܦ"
+                    title="Pe"
                   >
-                    
                     ܦ
-                    
-                  </span>
+                  </div>
                 </span>
                 <span
                   className="button is-outlined"
                   onClick={[Function]}
                 >
-                  <span
+                  <div
                     style={
                       Object {
                         "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
                         "fontSize": "2em",
+                        "verticalAlign": "center",
                       }
                     }
-                    title="ܨ"
+                    title="Sadhe"
                   >
-                    
                     ܨ
-                    
-                  </span>
+                  </div>
                 </span>
                 <span
                   className="button is-outlined"
                   onClick={[Function]}
                 >
-                  <span
+                  <div
                     style={
                       Object {
                         "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
                         "fontSize": "2em",
+                        "verticalAlign": "center",
                       }
                     }
-                    title="ܩ"
+                    title="Qaph"
                   >
-                    
                     ܩ
-                    
-                  </span>
+                  </div>
                 </span>
                 <span
                   className="button is-outlined"
                   onClick={[Function]}
                 >
-                  <span
+                  <div
                     style={
                       Object {
                         "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
                         "fontSize": "2em",
+                        "verticalAlign": "center",
                       }
                     }
-                    title="ܪ"
+                    title="Rish (Angular)"
                   >
-                    
                     ܪ
-                    
-                  </span>
+                  </div>
                 </span>
                 <span
                   className="button is-outlined"
                   onClick={[Function]}
                 >
-                  <span
+                  <div
                     style={
                       Object {
                         "direction": "rtl",
                         "fontFamily": "SertoJerusalem",
                         "fontSize": "2em",
+                        "verticalAlign": "center",
                       }
                     }
-                    title="ܪ"
+                    title="Rish (Round)"
                   >
-                    
                     ܪ
-                    
-                  </span>
+                  </div>
                 </span>
                 <span
                   className="button is-outlined"
                   onClick={[Function]}
                 >
-                  <span
+                  <div
                     style={
                       Object {
                         "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
                         "fontSize": "2em",
+                        "verticalAlign": "center",
                       }
                     }
-                    title="ܫ"
+                    title="Shin"
                   >
-                    
                     ܫ
-                    
-                  </span>
+                  </div>
                 </span>
                 <span
                   className="button is-outlined"
                   onClick={[Function]}
                 >
-                  <span
+                  <div
                     style={
                       Object {
                         "direction": "rtl",
                         "fontFamily": "EstrangeloEdessa",
                         "fontSize": "2em",
+                        "verticalAlign": "center",
                       }
                     }
-                    title="ܬ"
+                    title="Taw (Looped)"
                   >
-                    
                     ܬ
-                    
-                  </span>
+                  </div>
                 </span>
                 <span
                   className="button is-outlined"
                   onClick={[Function]}
                 >
-                  <span
+                  <div
                     style={
                       Object {
-                        "direction": "rtl",
-                        "fontFamily": "SertoJerusalem",
-                        "fontSize": "2em",
+                        "verticalAlign": "center",
                       }
                     }
-                    title="ܬ"
+                    title="Taw (Triangular)"
                   >
-                    ‍
-                    ܬ
-                    
-                  </span>
+                    <img
+                      className="button-image "
+                      src="/scriptchart/assets/font_glyphs/taw_triangular.svg"
+                    />
+                  </div>
                 </span>
                 <span
                   className="button is-outlined"
                   onClick={[Function]}
                 >
-                  <span
+                  <div
                     style={
                       Object {
                         "direction": "rtl",
                         "fontFamily": "SertoJerusalem",
                         "fontSize": "2em",
+                        "verticalAlign": "center",
                       }
                     }
-                    title="ܬ"
+                    title="Taw (L-shaped)"
                   >
-                    
                     ܬ
-                    
-                  </span>
+                  </div>
                 </span>
               </div>
             </div>

--- a/js/components/__tests__/__snapshots__/ChartAccordion.test.js.snap
+++ b/js/components/__tests__/__snapshots__/ChartAccordion.test.js.snap
@@ -65,6 +65,7 @@ exports[`ChartAccordion test ChartAccordion should match snapshot 1`] = `
       >
         <LetterButton
           buttonClass="button is-outlined"
+          isButton={true}
           key="2"
           letter={
             <SyriacLetter
@@ -75,6 +76,7 @@ exports[`ChartAccordion test ChartAccordion should match snapshot 1`] = `
         />
         <LetterButton
           buttonClass="button is-outlined"
+          isButton={true}
           key="4"
           letter={
             <SyriacLetter
@@ -85,6 +87,7 @@ exports[`ChartAccordion test ChartAccordion should match snapshot 1`] = `
         />
         <LetterButton
           buttonClass="button is-outlined"
+          isButton={true}
           key="9"
           letter={
             <SyriacLetter

--- a/js/components/__tests__/__snapshots__/LetterButton.test.js.snap
+++ b/js/components/__tests__/__snapshots__/LetterButton.test.js.snap
@@ -3,5 +3,7 @@
 exports[`LetterButton test LetterButton should match snapshot 1`] = `
 <span
   onClick={[Function]}
-/>
+>
+  <div />
+</span>
 `;

--- a/js/components/__tests__/__snapshots__/LettersLoader.test.js.snap
+++ b/js/components/__tests__/__snapshots__/LettersLoader.test.js.snap
@@ -8,666 +8,631 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
     className="button is-success"
     onClick={[Function]}
   >
-    <span
+    <div
       style={
         Object {
           "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
           "fontSize": "2em",
+          "verticalAlign": "center",
         }
       }
-      title="ܐ"
+      title="Alaph (Angular)"
     >
-      
       ܐ
-      
-    </span>
+    </div>
   </span>
   <span
     className="button is-success"
     onClick={[Function]}
   >
-    <span
+    <div
       style={
         Object {
           "direction": "rtl",
           "fontFamily": "SertoJerusalem",
           "fontSize": "2em",
+          "verticalAlign": "center",
         }
       }
-      title="ܐ"
+      title="Alaph (Round)"
     >
-      
       ܐ
-      
-    </span>
+    </div>
   </span>
   <span
     className="button is-outlined"
     onClick={[Function]}
   >
-    <span
+    <div
       style={
         Object {
           "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
           "fontSize": "2em",
+          "verticalAlign": "center",
         }
       }
-      title="ܒ"
+      title="Beth"
     >
-      
       ܒ
-      
-    </span>
+    </div>
   </span>
   <span
     className="button is-outlined"
     onClick={[Function]}
   >
-    <span
+    <div
       style={
         Object {
           "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
           "fontSize": "2em",
+          "verticalAlign": "center",
         }
       }
-      title="ܓ"
+      title="Gamal"
     >
-      
       ܓ
-      
-    </span>
+    </div>
   </span>
   <span
     className="button is-outlined"
     onClick={[Function]}
   >
-    <span
+    <div
       style={
         Object {
           "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
           "fontSize": "2em",
+          "verticalAlign": "center",
         }
       }
-      title="ܕ"
+      title="Dalath (Angular)"
     >
-      
       ܕ
-      
-    </span>
+    </div>
   </span>
   <span
     className="button is-outlined"
     onClick={[Function]}
   >
-    <span
+    <div
       style={
         Object {
           "direction": "rtl",
           "fontFamily": "SertoJerusalem",
           "fontSize": "2em",
+          "verticalAlign": "center",
         }
       }
-      title="ܕ"
+      title="Dalath (Round)"
     >
-      
       ܕ
-      
-    </span>
+    </div>
   </span>
   <span
     className="button is-outlined"
     onClick={[Function]}
   >
-    <span
+    <div
       style={
         Object {
           "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
           "fontSize": "2em",
+          "verticalAlign": "center",
         }
       }
-      title="ܗ"
+      title="He (Angular)"
     >
-      
       ܗ
-      
-    </span>
+    </div>
   </span>
   <span
     className="button is-outlined"
     onClick={[Function]}
   >
-    <span
+    <div
       style={
         Object {
           "direction": "rtl",
           "fontFamily": "SertoJerusalem",
           "fontSize": "2em",
+          "verticalAlign": "center",
         }
       }
-      title="ܗ"
+      title="He (Round)"
     >
-      
       ܗ
-      
-    </span>
+    </div>
   </span>
   <span
     className="button is-outlined"
     onClick={[Function]}
   >
-    <span
+    <div
       style={
         Object {
           "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
           "fontSize": "2em",
+          "verticalAlign": "center",
         }
       }
-      title="ܘ"
+      title="Waw"
     >
-      
       ܘ
-      
-    </span>
+    </div>
   </span>
   <span
     className="button is-outlined"
     onClick={[Function]}
   >
-    <span
+    <div
       style={
         Object {
           "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
           "fontSize": "2em",
+          "verticalAlign": "center",
         }
       }
-      title="ܙ"
+      title="Zain"
     >
-      
       ܙ
-      
-    </span>
+    </div>
   </span>
   <span
     className="button is-outlined"
     onClick={[Function]}
   >
-    <span
+    <div
       style={
         Object {
           "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
           "fontSize": "2em",
+          "verticalAlign": "center",
         }
       }
-      title="ܚ"
+      title="Heth"
     >
-      
       ܚ
-      
-    </span>
+    </div>
   </span>
   <span
     className="button is-outlined"
     onClick={[Function]}
   >
-    <span
+    <div
       style={
         Object {
           "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
           "fontSize": "2em",
+          "verticalAlign": "center",
         }
       }
-      title="ܛ"
+      title="Teth"
     >
-      
       ܛ
-      
-    </span>
+    </div>
   </span>
   <span
     className="button is-outlined"
     onClick={[Function]}
   >
-    <span
+    <div
+      style={
+        Object {
+          "verticalAlign": "center",
+        }
+      }
+      title="Yudh (Connected)"
+    >
+      <img
+        className="button-image "
+        src="/scriptchart/assets/font_glyphs/yudh_connected.svg"
+      />
+    </div>
+  </span>
+  <span
+    className="button is-outlined"
+    onClick={[Function]}
+  >
+    <div
       style={
         Object {
           "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
           "fontSize": "2em",
+          "verticalAlign": "center",
         }
       }
-      title="ܝ"
+      title="Yudh (Stand-alone)"
     >
-      ‍
       ܝ
-      ‍
-    </span>
+    </div>
   </span>
   <span
     className="button is-outlined"
     onClick={[Function]}
   >
-    <span
+    <div
       style={
         Object {
-          "direction": "rtl",
-          "fontFamily": "EstrangeloEdessa",
-          "fontSize": "2em",
+          "verticalAlign": "center",
         }
       }
-      title="ܝ"
+      title="Kaph"
     >
-      
-      ܝ
-      
-    </span>
+      <img
+        className="button-image "
+        src="/scriptchart/assets/font_glyphs/kaph.svg"
+      />
+    </div>
   </span>
   <span
     className="button is-outlined"
     onClick={[Function]}
   >
-    <span
+    <div
       style={
         Object {
           "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
           "fontSize": "2em",
+          "verticalAlign": "center",
         }
       }
-      title="ܟ"
+      title="Kaph (Final)"
     >
-      
       ܟ
-      ‍
-    </span>
+    </div>
   </span>
   <span
     className="button is-outlined"
     onClick={[Function]}
   >
-    <span
+    <div
       style={
         Object {
           "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
           "fontSize": "2em",
+          "verticalAlign": "center",
         }
       }
-      title="ܟ"
+      title="Lamadh (Final, open)"
     >
-      
-      ܟ
-      
-    </span>
-  </span>
-  <span
-    className="button is-outlined"
-    onClick={[Function]}
-  >
-    <span
-      style={
-        Object {
-          "direction": "rtl",
-          "fontFamily": "EstrangeloEdessa",
-          "fontSize": "2em",
-        }
-      }
-      title="ܠ"
-    >
-      
       ܠ
-      
-    </span>
+    </div>
   </span>
   <span
     className="button is-outlined"
     onClick={[Function]}
   >
-    <span
+    <div
       style={
         Object {
-          "direction": "rtl",
-          "fontFamily": "EstrangeloEdessa",
-          "fontSize": "2em",
+          "verticalAlign": "center",
         }
       }
-      title="ܠ"
+      title="Lamadh"
     >
-      ‍
-      ܠ
-      
-    </span>
+      <img
+        className="button-image "
+        src="/scriptchart/assets/font_glyphs/lamadh.svg"
+      />
+    </div>
   </span>
   <span
     className="button is-outlined"
     onClick={[Function]}
   >
-    <span
+    <div
       style={
         Object {
           "direction": "rtl",
           "fontFamily": "SertoJerusalem",
           "fontSize": "2em",
+          "verticalAlign": "center",
         }
       }
-      title="ܠ"
+      title="Lamadh (Final, closed)"
     >
-      
       ܠ
-      
-    </span>
+    </div>
   </span>
   <span
     className="button is-outlined"
     onClick={[Function]}
   >
-    <span
+    <div
+      style={
+        Object {
+          "verticalAlign": "center",
+        }
+      }
+      title="Mim"
+    >
+      <img
+        className="button-image "
+        src="/scriptchart/assets/font_glyphs/mim.svg"
+      />
+    </div>
+  </span>
+  <span
+    className="button is-outlined"
+    onClick={[Function]}
+  >
+    <div
       style={
         Object {
           "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
           "fontSize": "2em",
+          "verticalAlign": "center",
         }
       }
-      title="ܡ"
+      title="Mim (Final)"
     >
-      
       ܡ
-      ‍
-    </span>
+    </div>
   </span>
   <span
     className="button is-outlined"
     onClick={[Function]}
   >
-    <span
+    <div
       style={
         Object {
-          "direction": "rtl",
-          "fontFamily": "EstrangeloEdessa",
-          "fontSize": "2em",
+          "verticalAlign": "center",
         }
       }
-      title="ܡ"
+      title="Nun"
     >
-      
-      ܡ
-      
-    </span>
+      <img
+        className="button-image "
+        src="/scriptchart/assets/font_glyphs/nun.svg"
+      />
+    </div>
   </span>
   <span
     className="button is-outlined"
     onClick={[Function]}
   >
-    <span
+    <div
+      style={
+        Object {
+          "verticalAlign": "center",
+        }
+      }
+      title="Nun (Final, connected)"
+    >
+      <img
+        className="button-image "
+        src="/scriptchart/assets/font_glyphs/nun_final.svg"
+      />
+    </div>
+  </span>
+  <span
+    className="button is-outlined"
+    onClick={[Function]}
+  >
+    <div
       style={
         Object {
           "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
           "fontSize": "2em",
+          "verticalAlign": "center",
         }
       }
-      title="ܢ"
+      title="Nun (Final, unconnected)"
     >
-      
       ܢ
-      ‍
-    </span>
+    </div>
   </span>
   <span
     className="button is-outlined"
     onClick={[Function]}
   >
-    <span
+    <div
       style={
         Object {
           "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
           "fontSize": "2em",
+          "verticalAlign": "center",
         }
       }
-      title="ܢ"
+      title="Semkath"
     >
-      ‍
-      ܢ
-      
-    </span>
-  </span>
-  <span
-    className="button is-outlined"
-    onClick={[Function]}
-  >
-    <span
-      style={
-        Object {
-          "direction": "rtl",
-          "fontFamily": "EstrangeloEdessa",
-          "fontSize": "2em",
-        }
-      }
-      title="ܢ"
-    >
-      
-      ܢ
-      
-    </span>
-  </span>
-  <span
-    className="button is-outlined"
-    onClick={[Function]}
-  >
-    <span
-      style={
-        Object {
-          "direction": "rtl",
-          "fontFamily": "EstrangeloEdessa",
-          "fontSize": "2em",
-        }
-      }
-      title="ܣ"
-    >
-      
       ܣ
-      
-    </span>
+    </div>
   </span>
   <span
     className="button is-outlined"
     onClick={[Function]}
   >
-    <span
+    <div
       style={
         Object {
           "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
           "fontSize": "2em",
+          "verticalAlign": "center",
         }
       }
-      title="ܥ"
+      title="Ayin"
     >
-      
       ܥ
-      
-    </span>
+    </div>
   </span>
   <span
     className="button is-outlined"
     onClick={[Function]}
   >
-    <span
+    <div
       style={
         Object {
           "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
           "fontSize": "2em",
+          "verticalAlign": "center",
         }
       }
-      title="ܦ"
+      title="Pe"
     >
-      
       ܦ
-      
-    </span>
+    </div>
   </span>
   <span
     className="button is-outlined"
     onClick={[Function]}
   >
-    <span
+    <div
       style={
         Object {
           "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
           "fontSize": "2em",
+          "verticalAlign": "center",
         }
       }
-      title="ܨ"
+      title="Sadhe"
     >
-      
       ܨ
-      
-    </span>
+    </div>
   </span>
   <span
     className="button is-outlined"
     onClick={[Function]}
   >
-    <span
+    <div
       style={
         Object {
           "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
           "fontSize": "2em",
+          "verticalAlign": "center",
         }
       }
-      title="ܩ"
+      title="Qaph"
     >
-      
       ܩ
-      
-    </span>
+    </div>
   </span>
   <span
     className="button is-outlined"
     onClick={[Function]}
   >
-    <span
+    <div
       style={
         Object {
           "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
           "fontSize": "2em",
+          "verticalAlign": "center",
         }
       }
-      title="ܪ"
+      title="Rish (Angular)"
     >
-      
       ܪ
-      
-    </span>
+    </div>
   </span>
   <span
     className="button is-outlined"
     onClick={[Function]}
   >
-    <span
+    <div
       style={
         Object {
           "direction": "rtl",
           "fontFamily": "SertoJerusalem",
           "fontSize": "2em",
+          "verticalAlign": "center",
         }
       }
-      title="ܪ"
+      title="Rish (Round)"
     >
-      
       ܪ
-      
-    </span>
+    </div>
   </span>
   <span
     className="button is-outlined"
     onClick={[Function]}
   >
-    <span
+    <div
       style={
         Object {
           "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
           "fontSize": "2em",
+          "verticalAlign": "center",
         }
       }
-      title="ܫ"
+      title="Shin"
     >
-      
       ܫ
-      
-    </span>
+    </div>
   </span>
   <span
     className="button is-outlined"
     onClick={[Function]}
   >
-    <span
+    <div
       style={
         Object {
           "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
           "fontSize": "2em",
+          "verticalAlign": "center",
         }
       }
-      title="ܬ"
+      title="Taw (Looped)"
     >
-      
       ܬ
-      
-    </span>
+    </div>
   </span>
   <span
     className="button is-outlined"
     onClick={[Function]}
   >
-    <span
+    <div
       style={
         Object {
-          "direction": "rtl",
-          "fontFamily": "SertoJerusalem",
-          "fontSize": "2em",
+          "verticalAlign": "center",
         }
       }
-      title="ܬ"
+      title="Taw (Triangular)"
     >
-      ‍
-      ܬ
-      
-    </span>
+      <img
+        className="button-image "
+        src="/scriptchart/assets/font_glyphs/taw_triangular.svg"
+      />
+    </div>
   </span>
   <span
     className="button is-outlined"
     onClick={[Function]}
   >
-    <span
+    <div
       style={
         Object {
           "direction": "rtl",
           "fontFamily": "SertoJerusalem",
           "fontSize": "2em",
+          "verticalAlign": "center",
         }
       }
-      title="ܬ"
+      title="Taw (L-shaped)"
     >
-      
       ܬ
-      
-    </span>
+    </div>
   </span>
 </div>
 `;

--- a/js/components/__tests__/__snapshots__/LettersLoader.test.js.snap
+++ b/js/components/__tests__/__snapshots__/LettersLoader.test.js.snap
@@ -9,12 +9,10 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
     onClick={[Function]}
   >
     <div
+      className="button-letter"
       style={
         Object {
-          "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
-          "fontSize": "2em",
-          "verticalAlign": "center",
         }
       }
       title="Alaph (Angular)"
@@ -27,12 +25,10 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
     onClick={[Function]}
   >
     <div
+      className="button-letter"
       style={
         Object {
-          "direction": "rtl",
           "fontFamily": "SertoJerusalem",
-          "fontSize": "2em",
-          "verticalAlign": "center",
         }
       }
       title="Alaph (Round)"
@@ -45,12 +41,10 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
     onClick={[Function]}
   >
     <div
+      className="button-letter"
       style={
         Object {
-          "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
-          "fontSize": "2em",
-          "verticalAlign": "center",
         }
       }
       title="Beth"
@@ -63,12 +57,10 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
     onClick={[Function]}
   >
     <div
+      className="button-letter"
       style={
         Object {
-          "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
-          "fontSize": "2em",
-          "verticalAlign": "center",
         }
       }
       title="Gamal"
@@ -81,12 +73,10 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
     onClick={[Function]}
   >
     <div
+      className="button-letter"
       style={
         Object {
-          "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
-          "fontSize": "2em",
-          "verticalAlign": "center",
         }
       }
       title="Dalath (Angular)"
@@ -99,12 +89,10 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
     onClick={[Function]}
   >
     <div
+      className="button-letter"
       style={
         Object {
-          "direction": "rtl",
           "fontFamily": "SertoJerusalem",
-          "fontSize": "2em",
-          "verticalAlign": "center",
         }
       }
       title="Dalath (Round)"
@@ -117,12 +105,10 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
     onClick={[Function]}
   >
     <div
+      className="button-letter"
       style={
         Object {
-          "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
-          "fontSize": "2em",
-          "verticalAlign": "center",
         }
       }
       title="He (Angular)"
@@ -135,12 +121,10 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
     onClick={[Function]}
   >
     <div
+      className="button-letter"
       style={
         Object {
-          "direction": "rtl",
           "fontFamily": "SertoJerusalem",
-          "fontSize": "2em",
-          "verticalAlign": "center",
         }
       }
       title="He (Round)"
@@ -153,12 +137,10 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
     onClick={[Function]}
   >
     <div
+      className="button-letter"
       style={
         Object {
-          "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
-          "fontSize": "2em",
-          "verticalAlign": "center",
         }
       }
       title="Waw"
@@ -171,12 +153,10 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
     onClick={[Function]}
   >
     <div
+      className="button-letter"
       style={
         Object {
-          "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
-          "fontSize": "2em",
-          "verticalAlign": "center",
         }
       }
       title="Zain"
@@ -189,12 +169,10 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
     onClick={[Function]}
   >
     <div
+      className="button-letter"
       style={
         Object {
-          "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
-          "fontSize": "2em",
-          "verticalAlign": "center",
         }
       }
       title="Heth"
@@ -207,12 +185,10 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
     onClick={[Function]}
   >
     <div
+      className="button-letter"
       style={
         Object {
-          "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
-          "fontSize": "2em",
-          "verticalAlign": "center",
         }
       }
       title="Teth"
@@ -233,7 +209,7 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
       title="Yudh (Connected)"
     >
       <img
-        className="button-image "
+        className="button-svg "
         src="/scriptchart/assets/font_glyphs/yudh_connected.svg"
       />
     </div>
@@ -243,12 +219,10 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
     onClick={[Function]}
   >
     <div
+      className="button-letter"
       style={
         Object {
-          "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
-          "fontSize": "2em",
-          "verticalAlign": "center",
         }
       }
       title="Yudh (Stand-alone)"
@@ -269,7 +243,7 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
       title="Kaph"
     >
       <img
-        className="button-image "
+        className="button-svg "
         src="/scriptchart/assets/font_glyphs/kaph.svg"
       />
     </div>
@@ -279,12 +253,10 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
     onClick={[Function]}
   >
     <div
+      className="button-letter"
       style={
         Object {
-          "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
-          "fontSize": "2em",
-          "verticalAlign": "center",
         }
       }
       title="Kaph (Final)"
@@ -297,12 +269,10 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
     onClick={[Function]}
   >
     <div
+      className="button-letter"
       style={
         Object {
-          "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
-          "fontSize": "2em",
-          "verticalAlign": "center",
         }
       }
       title="Lamadh (Final, open)"
@@ -323,7 +293,7 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
       title="Lamadh"
     >
       <img
-        className="button-image "
+        className="button-svg "
         src="/scriptchart/assets/font_glyphs/lamadh.svg"
       />
     </div>
@@ -333,12 +303,10 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
     onClick={[Function]}
   >
     <div
+      className="button-letter"
       style={
         Object {
-          "direction": "rtl",
           "fontFamily": "SertoJerusalem",
-          "fontSize": "2em",
-          "verticalAlign": "center",
         }
       }
       title="Lamadh (Final, closed)"
@@ -359,7 +327,7 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
       title="Mim"
     >
       <img
-        className="button-image "
+        className="button-svg "
         src="/scriptchart/assets/font_glyphs/mim.svg"
       />
     </div>
@@ -369,12 +337,10 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
     onClick={[Function]}
   >
     <div
+      className="button-letter"
       style={
         Object {
-          "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
-          "fontSize": "2em",
-          "verticalAlign": "center",
         }
       }
       title="Mim (Final)"
@@ -395,7 +361,7 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
       title="Nun"
     >
       <img
-        className="button-image "
+        className="button-svg "
         src="/scriptchart/assets/font_glyphs/nun.svg"
       />
     </div>
@@ -413,7 +379,7 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
       title="Nun (Final, connected)"
     >
       <img
-        className="button-image "
+        className="button-svg "
         src="/scriptchart/assets/font_glyphs/nun_final.svg"
       />
     </div>
@@ -423,12 +389,10 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
     onClick={[Function]}
   >
     <div
+      className="button-letter"
       style={
         Object {
-          "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
-          "fontSize": "2em",
-          "verticalAlign": "center",
         }
       }
       title="Nun (Final, unconnected)"
@@ -441,12 +405,10 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
     onClick={[Function]}
   >
     <div
+      className="button-letter"
       style={
         Object {
-          "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
-          "fontSize": "2em",
-          "verticalAlign": "center",
         }
       }
       title="Semkath"
@@ -459,12 +421,10 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
     onClick={[Function]}
   >
     <div
+      className="button-letter"
       style={
         Object {
-          "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
-          "fontSize": "2em",
-          "verticalAlign": "center",
         }
       }
       title="Ayin"
@@ -477,12 +437,10 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
     onClick={[Function]}
   >
     <div
+      className="button-letter"
       style={
         Object {
-          "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
-          "fontSize": "2em",
-          "verticalAlign": "center",
         }
       }
       title="Pe"
@@ -495,12 +453,10 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
     onClick={[Function]}
   >
     <div
+      className="button-letter"
       style={
         Object {
-          "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
-          "fontSize": "2em",
-          "verticalAlign": "center",
         }
       }
       title="Sadhe"
@@ -513,12 +469,10 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
     onClick={[Function]}
   >
     <div
+      className="button-letter"
       style={
         Object {
-          "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
-          "fontSize": "2em",
-          "verticalAlign": "center",
         }
       }
       title="Qaph"
@@ -531,12 +485,10 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
     onClick={[Function]}
   >
     <div
+      className="button-letter"
       style={
         Object {
-          "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
-          "fontSize": "2em",
-          "verticalAlign": "center",
         }
       }
       title="Rish (Angular)"
@@ -549,12 +501,10 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
     onClick={[Function]}
   >
     <div
+      className="button-letter"
       style={
         Object {
-          "direction": "rtl",
           "fontFamily": "SertoJerusalem",
-          "fontSize": "2em",
-          "verticalAlign": "center",
         }
       }
       title="Rish (Round)"
@@ -567,12 +517,10 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
     onClick={[Function]}
   >
     <div
+      className="button-letter"
       style={
         Object {
-          "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
-          "fontSize": "2em",
-          "verticalAlign": "center",
         }
       }
       title="Shin"
@@ -585,12 +533,10 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
     onClick={[Function]}
   >
     <div
+      className="button-letter"
       style={
         Object {
-          "direction": "rtl",
           "fontFamily": "EstrangeloEdessa",
-          "fontSize": "2em",
-          "verticalAlign": "center",
         }
       }
       title="Taw (Looped)"
@@ -611,7 +557,7 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
       title="Taw (Triangular)"
     >
       <img
-        className="button-image "
+        className="button-svg "
         src="/scriptchart/assets/font_glyphs/taw_triangular.svg"
       />
     </div>
@@ -621,12 +567,10 @@ exports[`LettersLoader test LettersLoader should match snapshot 1`] = `
     onClick={[Function]}
   >
     <div
+      className="button-letter"
       style={
         Object {
-          "direction": "rtl",
           "fontFamily": "SertoJerusalem",
-          "fontSize": "2em",
-          "verticalAlign": "center",
         }
       }
       title="Taw (L-shaped)"

--- a/js/components/__tests__/__snapshots__/ManuscriptForm.test.js.snap
+++ b/js/components/__tests__/__snapshots__/ManuscriptForm.test.js.snap
@@ -233,12 +233,10 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
         onClick={[Function]}
       >
         <div
+          className="button-letter"
           style={
             Object {
-              "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
-              "fontSize": "2em",
-              "verticalAlign": "center",
             }
           }
           title="Alaph (Angular)"
@@ -251,12 +249,10 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
         onClick={[Function]}
       >
         <div
+          className="button-letter"
           style={
             Object {
-              "direction": "rtl",
               "fontFamily": "SertoJerusalem",
-              "fontSize": "2em",
-              "verticalAlign": "center",
             }
           }
           title="Alaph (Round)"
@@ -269,12 +265,10 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
         onClick={[Function]}
       >
         <div
+          className="button-letter"
           style={
             Object {
-              "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
-              "fontSize": "2em",
-              "verticalAlign": "center",
             }
           }
           title="Beth"
@@ -287,12 +281,10 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
         onClick={[Function]}
       >
         <div
+          className="button-letter"
           style={
             Object {
-              "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
-              "fontSize": "2em",
-              "verticalAlign": "center",
             }
           }
           title="Gamal"
@@ -305,12 +297,10 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
         onClick={[Function]}
       >
         <div
+          className="button-letter"
           style={
             Object {
-              "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
-              "fontSize": "2em",
-              "verticalAlign": "center",
             }
           }
           title="Dalath (Angular)"
@@ -323,12 +313,10 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
         onClick={[Function]}
       >
         <div
+          className="button-letter"
           style={
             Object {
-              "direction": "rtl",
               "fontFamily": "SertoJerusalem",
-              "fontSize": "2em",
-              "verticalAlign": "center",
             }
           }
           title="Dalath (Round)"
@@ -341,12 +329,10 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
         onClick={[Function]}
       >
         <div
+          className="button-letter"
           style={
             Object {
-              "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
-              "fontSize": "2em",
-              "verticalAlign": "center",
             }
           }
           title="He (Angular)"
@@ -359,12 +345,10 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
         onClick={[Function]}
       >
         <div
+          className="button-letter"
           style={
             Object {
-              "direction": "rtl",
               "fontFamily": "SertoJerusalem",
-              "fontSize": "2em",
-              "verticalAlign": "center",
             }
           }
           title="He (Round)"
@@ -377,12 +361,10 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
         onClick={[Function]}
       >
         <div
+          className="button-letter"
           style={
             Object {
-              "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
-              "fontSize": "2em",
-              "verticalAlign": "center",
             }
           }
           title="Waw"
@@ -395,12 +377,10 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
         onClick={[Function]}
       >
         <div
+          className="button-letter"
           style={
             Object {
-              "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
-              "fontSize": "2em",
-              "verticalAlign": "center",
             }
           }
           title="Zain"
@@ -413,12 +393,10 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
         onClick={[Function]}
       >
         <div
+          className="button-letter"
           style={
             Object {
-              "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
-              "fontSize": "2em",
-              "verticalAlign": "center",
             }
           }
           title="Heth"
@@ -431,12 +409,10 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
         onClick={[Function]}
       >
         <div
+          className="button-letter"
           style={
             Object {
-              "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
-              "fontSize": "2em",
-              "verticalAlign": "center",
             }
           }
           title="Teth"
@@ -457,7 +433,7 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
           title="Yudh (Connected)"
         >
           <img
-            className="button-image "
+            className="button-svg "
             src="/scriptchart/assets/font_glyphs/yudh_connected.svg"
           />
         </div>
@@ -467,12 +443,10 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
         onClick={[Function]}
       >
         <div
+          className="button-letter"
           style={
             Object {
-              "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
-              "fontSize": "2em",
-              "verticalAlign": "center",
             }
           }
           title="Yudh (Stand-alone)"
@@ -493,7 +467,7 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
           title="Kaph"
         >
           <img
-            className="button-image "
+            className="button-svg "
             src="/scriptchart/assets/font_glyphs/kaph.svg"
           />
         </div>
@@ -503,12 +477,10 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
         onClick={[Function]}
       >
         <div
+          className="button-letter"
           style={
             Object {
-              "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
-              "fontSize": "2em",
-              "verticalAlign": "center",
             }
           }
           title="Kaph (Final)"
@@ -521,12 +493,10 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
         onClick={[Function]}
       >
         <div
+          className="button-letter"
           style={
             Object {
-              "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
-              "fontSize": "2em",
-              "verticalAlign": "center",
             }
           }
           title="Lamadh (Final, open)"
@@ -547,7 +517,7 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
           title="Lamadh"
         >
           <img
-            className="button-image "
+            className="button-svg "
             src="/scriptchart/assets/font_glyphs/lamadh.svg"
           />
         </div>
@@ -557,12 +527,10 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
         onClick={[Function]}
       >
         <div
+          className="button-letter"
           style={
             Object {
-              "direction": "rtl",
               "fontFamily": "SertoJerusalem",
-              "fontSize": "2em",
-              "verticalAlign": "center",
             }
           }
           title="Lamadh (Final, closed)"
@@ -583,7 +551,7 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
           title="Mim"
         >
           <img
-            className="button-image "
+            className="button-svg "
             src="/scriptchart/assets/font_glyphs/mim.svg"
           />
         </div>
@@ -593,12 +561,10 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
         onClick={[Function]}
       >
         <div
+          className="button-letter"
           style={
             Object {
-              "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
-              "fontSize": "2em",
-              "verticalAlign": "center",
             }
           }
           title="Mim (Final)"
@@ -619,7 +585,7 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
           title="Nun"
         >
           <img
-            className="button-image "
+            className="button-svg "
             src="/scriptchart/assets/font_glyphs/nun.svg"
           />
         </div>
@@ -637,7 +603,7 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
           title="Nun (Final, connected)"
         >
           <img
-            className="button-image "
+            className="button-svg "
             src="/scriptchart/assets/font_glyphs/nun_final.svg"
           />
         </div>
@@ -647,12 +613,10 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
         onClick={[Function]}
       >
         <div
+          className="button-letter"
           style={
             Object {
-              "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
-              "fontSize": "2em",
-              "verticalAlign": "center",
             }
           }
           title="Nun (Final, unconnected)"
@@ -665,12 +629,10 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
         onClick={[Function]}
       >
         <div
+          className="button-letter"
           style={
             Object {
-              "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
-              "fontSize": "2em",
-              "verticalAlign": "center",
             }
           }
           title="Semkath"
@@ -683,12 +645,10 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
         onClick={[Function]}
       >
         <div
+          className="button-letter"
           style={
             Object {
-              "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
-              "fontSize": "2em",
-              "verticalAlign": "center",
             }
           }
           title="Ayin"
@@ -701,12 +661,10 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
         onClick={[Function]}
       >
         <div
+          className="button-letter"
           style={
             Object {
-              "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
-              "fontSize": "2em",
-              "verticalAlign": "center",
             }
           }
           title="Pe"
@@ -719,12 +677,10 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
         onClick={[Function]}
       >
         <div
+          className="button-letter"
           style={
             Object {
-              "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
-              "fontSize": "2em",
-              "verticalAlign": "center",
             }
           }
           title="Sadhe"
@@ -737,12 +693,10 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
         onClick={[Function]}
       >
         <div
+          className="button-letter"
           style={
             Object {
-              "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
-              "fontSize": "2em",
-              "verticalAlign": "center",
             }
           }
           title="Qaph"
@@ -755,12 +709,10 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
         onClick={[Function]}
       >
         <div
+          className="button-letter"
           style={
             Object {
-              "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
-              "fontSize": "2em",
-              "verticalAlign": "center",
             }
           }
           title="Rish (Angular)"
@@ -773,12 +725,10 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
         onClick={[Function]}
       >
         <div
+          className="button-letter"
           style={
             Object {
-              "direction": "rtl",
               "fontFamily": "SertoJerusalem",
-              "fontSize": "2em",
-              "verticalAlign": "center",
             }
           }
           title="Rish (Round)"
@@ -791,12 +741,10 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
         onClick={[Function]}
       >
         <div
+          className="button-letter"
           style={
             Object {
-              "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
-              "fontSize": "2em",
-              "verticalAlign": "center",
             }
           }
           title="Shin"
@@ -809,12 +757,10 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
         onClick={[Function]}
       >
         <div
+          className="button-letter"
           style={
             Object {
-              "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
-              "fontSize": "2em",
-              "verticalAlign": "center",
             }
           }
           title="Taw (Looped)"
@@ -835,7 +781,7 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
           title="Taw (Triangular)"
         >
           <img
-            className="button-image "
+            className="button-svg "
             src="/scriptchart/assets/font_glyphs/taw_triangular.svg"
           />
         </div>
@@ -845,12 +791,10 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
         onClick={[Function]}
       >
         <div
+          className="button-letter"
           style={
             Object {
-              "direction": "rtl",
               "fontFamily": "SertoJerusalem",
-              "fontSize": "2em",
-              "verticalAlign": "center",
             }
           }
           title="Taw (L-shaped)"

--- a/js/components/__tests__/__snapshots__/ManuscriptForm.test.js.snap
+++ b/js/components/__tests__/__snapshots__/ManuscriptForm.test.js.snap
@@ -232,666 +232,631 @@ exports[`ManuscriptForm test ManuscriptForm should match snapshot 1`] = `
         className="button is-outlined"
         onClick={[Function]}
       >
-        <span
+        <div
           style={
             Object {
               "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
               "fontSize": "2em",
+              "verticalAlign": "center",
             }
           }
-          title="ܐ"
+          title="Alaph (Angular)"
         >
-          
           ܐ
-          
-        </span>
+        </div>
       </span>
       <span
         className="button is-outlined"
         onClick={[Function]}
       >
-        <span
+        <div
           style={
             Object {
               "direction": "rtl",
               "fontFamily": "SertoJerusalem",
               "fontSize": "2em",
+              "verticalAlign": "center",
             }
           }
-          title="ܐ"
+          title="Alaph (Round)"
         >
-          
           ܐ
-          
-        </span>
+        </div>
       </span>
       <span
         className="button is-outlined"
         onClick={[Function]}
       >
-        <span
+        <div
           style={
             Object {
               "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
               "fontSize": "2em",
+              "verticalAlign": "center",
             }
           }
-          title="ܒ"
+          title="Beth"
         >
-          
           ܒ
-          
-        </span>
+        </div>
       </span>
       <span
         className="button is-outlined"
         onClick={[Function]}
       >
-        <span
+        <div
           style={
             Object {
               "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
               "fontSize": "2em",
+              "verticalAlign": "center",
             }
           }
-          title="ܓ"
+          title="Gamal"
         >
-          
           ܓ
-          
-        </span>
+        </div>
       </span>
       <span
         className="button is-outlined"
         onClick={[Function]}
       >
-        <span
+        <div
           style={
             Object {
               "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
               "fontSize": "2em",
+              "verticalAlign": "center",
             }
           }
-          title="ܕ"
+          title="Dalath (Angular)"
         >
-          
           ܕ
-          
-        </span>
+        </div>
       </span>
       <span
         className="button is-outlined"
         onClick={[Function]}
       >
-        <span
+        <div
           style={
             Object {
               "direction": "rtl",
               "fontFamily": "SertoJerusalem",
               "fontSize": "2em",
+              "verticalAlign": "center",
             }
           }
-          title="ܕ"
+          title="Dalath (Round)"
         >
-          
           ܕ
-          
-        </span>
+        </div>
       </span>
       <span
         className="button is-outlined"
         onClick={[Function]}
       >
-        <span
+        <div
           style={
             Object {
               "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
               "fontSize": "2em",
+              "verticalAlign": "center",
             }
           }
-          title="ܗ"
+          title="He (Angular)"
         >
-          
           ܗ
-          
-        </span>
+        </div>
       </span>
       <span
         className="button is-outlined"
         onClick={[Function]}
       >
-        <span
+        <div
           style={
             Object {
               "direction": "rtl",
               "fontFamily": "SertoJerusalem",
               "fontSize": "2em",
+              "verticalAlign": "center",
             }
           }
-          title="ܗ"
+          title="He (Round)"
         >
-          
           ܗ
-          
-        </span>
+        </div>
       </span>
       <span
         className="button is-outlined"
         onClick={[Function]}
       >
-        <span
+        <div
           style={
             Object {
               "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
               "fontSize": "2em",
+              "verticalAlign": "center",
             }
           }
-          title="ܘ"
+          title="Waw"
         >
-          
           ܘ
-          
-        </span>
+        </div>
       </span>
       <span
         className="button is-outlined"
         onClick={[Function]}
       >
-        <span
+        <div
           style={
             Object {
               "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
               "fontSize": "2em",
+              "verticalAlign": "center",
             }
           }
-          title="ܙ"
+          title="Zain"
         >
-          
           ܙ
-          
-        </span>
+        </div>
       </span>
       <span
         className="button is-outlined"
         onClick={[Function]}
       >
-        <span
+        <div
           style={
             Object {
               "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
               "fontSize": "2em",
+              "verticalAlign": "center",
             }
           }
-          title="ܚ"
+          title="Heth"
         >
-          
           ܚ
-          
-        </span>
+        </div>
       </span>
       <span
         className="button is-outlined"
         onClick={[Function]}
       >
-        <span
+        <div
           style={
             Object {
               "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
               "fontSize": "2em",
+              "verticalAlign": "center",
             }
           }
-          title="ܛ"
+          title="Teth"
         >
-          
           ܛ
-          
-        </span>
+        </div>
       </span>
       <span
         className="button is-outlined"
         onClick={[Function]}
       >
-        <span
+        <div
+          style={
+            Object {
+              "verticalAlign": "center",
+            }
+          }
+          title="Yudh (Connected)"
+        >
+          <img
+            className="button-image "
+            src="/scriptchart/assets/font_glyphs/yudh_connected.svg"
+          />
+        </div>
+      </span>
+      <span
+        className="button is-outlined"
+        onClick={[Function]}
+      >
+        <div
           style={
             Object {
               "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
               "fontSize": "2em",
+              "verticalAlign": "center",
             }
           }
-          title="ܝ"
+          title="Yudh (Stand-alone)"
         >
-          ‍
           ܝ
-          ‍
-        </span>
+        </div>
       </span>
       <span
         className="button is-outlined"
         onClick={[Function]}
       >
-        <span
+        <div
           style={
             Object {
-              "direction": "rtl",
-              "fontFamily": "EstrangeloEdessa",
-              "fontSize": "2em",
+              "verticalAlign": "center",
             }
           }
-          title="ܝ"
+          title="Kaph"
         >
-          
-          ܝ
-          
-        </span>
+          <img
+            className="button-image "
+            src="/scriptchart/assets/font_glyphs/kaph.svg"
+          />
+        </div>
       </span>
       <span
         className="button is-outlined"
         onClick={[Function]}
       >
-        <span
+        <div
           style={
             Object {
               "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
               "fontSize": "2em",
+              "verticalAlign": "center",
             }
           }
-          title="ܟ"
+          title="Kaph (Final)"
         >
-          
           ܟ
-          ‍
-        </span>
+        </div>
       </span>
       <span
         className="button is-outlined"
         onClick={[Function]}
       >
-        <span
+        <div
           style={
             Object {
               "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
               "fontSize": "2em",
+              "verticalAlign": "center",
             }
           }
-          title="ܟ"
+          title="Lamadh (Final, open)"
         >
-          
-          ܟ
-          
-        </span>
-      </span>
-      <span
-        className="button is-outlined"
-        onClick={[Function]}
-      >
-        <span
-          style={
-            Object {
-              "direction": "rtl",
-              "fontFamily": "EstrangeloEdessa",
-              "fontSize": "2em",
-            }
-          }
-          title="ܠ"
-        >
-          
           ܠ
-          
-        </span>
+        </div>
       </span>
       <span
         className="button is-outlined"
         onClick={[Function]}
       >
-        <span
+        <div
           style={
             Object {
-              "direction": "rtl",
-              "fontFamily": "EstrangeloEdessa",
-              "fontSize": "2em",
+              "verticalAlign": "center",
             }
           }
-          title="ܠ"
+          title="Lamadh"
         >
-          ‍
-          ܠ
-          
-        </span>
+          <img
+            className="button-image "
+            src="/scriptchart/assets/font_glyphs/lamadh.svg"
+          />
+        </div>
       </span>
       <span
         className="button is-outlined"
         onClick={[Function]}
       >
-        <span
+        <div
           style={
             Object {
               "direction": "rtl",
               "fontFamily": "SertoJerusalem",
               "fontSize": "2em",
+              "verticalAlign": "center",
             }
           }
-          title="ܠ"
+          title="Lamadh (Final, closed)"
         >
-          
           ܠ
-          
-        </span>
+        </div>
       </span>
       <span
         className="button is-outlined"
         onClick={[Function]}
       >
-        <span
+        <div
+          style={
+            Object {
+              "verticalAlign": "center",
+            }
+          }
+          title="Mim"
+        >
+          <img
+            className="button-image "
+            src="/scriptchart/assets/font_glyphs/mim.svg"
+          />
+        </div>
+      </span>
+      <span
+        className="button is-outlined"
+        onClick={[Function]}
+      >
+        <div
           style={
             Object {
               "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
               "fontSize": "2em",
+              "verticalAlign": "center",
             }
           }
-          title="ܡ"
+          title="Mim (Final)"
         >
-          
           ܡ
-          ‍
-        </span>
+        </div>
       </span>
       <span
         className="button is-outlined"
         onClick={[Function]}
       >
-        <span
+        <div
           style={
             Object {
-              "direction": "rtl",
-              "fontFamily": "EstrangeloEdessa",
-              "fontSize": "2em",
+              "verticalAlign": "center",
             }
           }
-          title="ܡ"
+          title="Nun"
         >
-          
-          ܡ
-          
-        </span>
+          <img
+            className="button-image "
+            src="/scriptchart/assets/font_glyphs/nun.svg"
+          />
+        </div>
       </span>
       <span
         className="button is-outlined"
         onClick={[Function]}
       >
-        <span
+        <div
+          style={
+            Object {
+              "verticalAlign": "center",
+            }
+          }
+          title="Nun (Final, connected)"
+        >
+          <img
+            className="button-image "
+            src="/scriptchart/assets/font_glyphs/nun_final.svg"
+          />
+        </div>
+      </span>
+      <span
+        className="button is-outlined"
+        onClick={[Function]}
+      >
+        <div
           style={
             Object {
               "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
               "fontSize": "2em",
+              "verticalAlign": "center",
             }
           }
-          title="ܢ"
+          title="Nun (Final, unconnected)"
         >
-          
           ܢ
-          ‍
-        </span>
+        </div>
       </span>
       <span
         className="button is-outlined"
         onClick={[Function]}
       >
-        <span
+        <div
           style={
             Object {
               "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
               "fontSize": "2em",
+              "verticalAlign": "center",
             }
           }
-          title="ܢ"
+          title="Semkath"
         >
-          ‍
-          ܢ
-          
-        </span>
-      </span>
-      <span
-        className="button is-outlined"
-        onClick={[Function]}
-      >
-        <span
-          style={
-            Object {
-              "direction": "rtl",
-              "fontFamily": "EstrangeloEdessa",
-              "fontSize": "2em",
-            }
-          }
-          title="ܢ"
-        >
-          
-          ܢ
-          
-        </span>
-      </span>
-      <span
-        className="button is-outlined"
-        onClick={[Function]}
-      >
-        <span
-          style={
-            Object {
-              "direction": "rtl",
-              "fontFamily": "EstrangeloEdessa",
-              "fontSize": "2em",
-            }
-          }
-          title="ܣ"
-        >
-          
           ܣ
-          
-        </span>
+        </div>
       </span>
       <span
         className="button is-outlined"
         onClick={[Function]}
       >
-        <span
+        <div
           style={
             Object {
               "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
               "fontSize": "2em",
+              "verticalAlign": "center",
             }
           }
-          title="ܥ"
+          title="Ayin"
         >
-          
           ܥ
-          
-        </span>
+        </div>
       </span>
       <span
         className="button is-outlined"
         onClick={[Function]}
       >
-        <span
+        <div
           style={
             Object {
               "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
               "fontSize": "2em",
+              "verticalAlign": "center",
             }
           }
-          title="ܦ"
+          title="Pe"
         >
-          
           ܦ
-          
-        </span>
+        </div>
       </span>
       <span
         className="button is-outlined"
         onClick={[Function]}
       >
-        <span
+        <div
           style={
             Object {
               "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
               "fontSize": "2em",
+              "verticalAlign": "center",
             }
           }
-          title="ܨ"
+          title="Sadhe"
         >
-          
           ܨ
-          
-        </span>
+        </div>
       </span>
       <span
         className="button is-outlined"
         onClick={[Function]}
       >
-        <span
+        <div
           style={
             Object {
               "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
               "fontSize": "2em",
+              "verticalAlign": "center",
             }
           }
-          title="ܩ"
+          title="Qaph"
         >
-          
           ܩ
-          
-        </span>
+        </div>
       </span>
       <span
         className="button is-outlined"
         onClick={[Function]}
       >
-        <span
+        <div
           style={
             Object {
               "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
               "fontSize": "2em",
+              "verticalAlign": "center",
             }
           }
-          title="ܪ"
+          title="Rish (Angular)"
         >
-          
           ܪ
-          
-        </span>
+        </div>
       </span>
       <span
         className="button is-outlined"
         onClick={[Function]}
       >
-        <span
+        <div
           style={
             Object {
               "direction": "rtl",
               "fontFamily": "SertoJerusalem",
               "fontSize": "2em",
+              "verticalAlign": "center",
             }
           }
-          title="ܪ"
+          title="Rish (Round)"
         >
-          
           ܪ
-          
-        </span>
+        </div>
       </span>
       <span
         className="button is-outlined"
         onClick={[Function]}
       >
-        <span
+        <div
           style={
             Object {
               "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
               "fontSize": "2em",
+              "verticalAlign": "center",
             }
           }
-          title="ܫ"
+          title="Shin"
         >
-          
           ܫ
-          
-        </span>
+        </div>
       </span>
       <span
         className="button is-outlined"
         onClick={[Function]}
       >
-        <span
+        <div
           style={
             Object {
               "direction": "rtl",
               "fontFamily": "EstrangeloEdessa",
               "fontSize": "2em",
+              "verticalAlign": "center",
             }
           }
-          title="ܬ"
+          title="Taw (Looped)"
         >
-          
           ܬ
-          
-        </span>
+        </div>
       </span>
       <span
         className="button is-outlined"
         onClick={[Function]}
       >
-        <span
+        <div
           style={
             Object {
-              "direction": "rtl",
-              "fontFamily": "SertoJerusalem",
-              "fontSize": "2em",
+              "verticalAlign": "center",
             }
           }
-          title="ܬ"
+          title="Taw (Triangular)"
         >
-          ‍
-          ܬ
-          
-        </span>
+          <img
+            className="button-image "
+            src="/scriptchart/assets/font_glyphs/taw_triangular.svg"
+          />
+        </div>
       </span>
       <span
         className="button is-outlined"
         onClick={[Function]}
       >
-        <span
+        <div
           style={
             Object {
               "direction": "rtl",
               "fontFamily": "SertoJerusalem",
               "fontSize": "2em",
+              "verticalAlign": "center",
             }
           }
-          title="ܬ"
+          title="Taw (L-shaped)"
         >
-          
           ܬ
-          
-        </span>
+        </div>
       </span>
     </div>
   </div>

--- a/js/components/__tests__/__snapshots__/SyriacLetter.test.js.snap
+++ b/js/components/__tests__/__snapshots__/SyriacLetter.test.js.snap
@@ -1,16 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SyriacLetter test SyriacLetter should match snapshot 1`] = `
-<span
-  style={
-    Object {
-      "direction": "rtl",
-      "fontFamily": undefined,
-      "fontSize": "2em",
-    }
-  }
->
-  
-  
-</span>
-`;
+exports[`SyriacLetter test SyriacLetter should match snapshot 1`] = `<div />`;

--- a/js/components/app.css
+++ b/js/components/app.css
@@ -21,4 +21,4 @@
 
 .small-padding {
     padding: 10px 10px 10px 10px;
-  }
+}

--- a/js/components/index.css
+++ b/js/components/index.css
@@ -76,6 +76,12 @@ tr:nth-child(even) {
   background-color: #f2f2f2
 }
 
-td .button-image {
-  margin-left: 0;
+.button-image {
+  margin-left: 0px;
+  height: 2em;
+  vertical-align: bottom
+}
+
+.button-clicked {
+  filter: invert(1)
 }

--- a/js/components/index.css
+++ b/js/components/index.css
@@ -75,3 +75,7 @@ td:hover {
 tr:nth-child(even) {
   background-color: #f2f2f2
 }
+
+td .button-image {
+  margin-left: 0;
+}

--- a/js/components/index.css
+++ b/js/components/index.css
@@ -73,15 +73,31 @@ td:hover {
 }
 
 tr:nth-child(even) {
-  background-color: #f2f2f2
+  background-color: #f2f2f2;
 }
 
-.button-image {
+.button-letter {
+  direction: rtl;
+  font-size: 2em;
+  vertical-align: center;
+}
+
+.chart-letter {
+  direction: rtl;
+  font-size: 3em;
+}
+
+.button-svg {
   margin-left: 0px;
   height: 2em;
-  vertical-align: bottom
+  vertical-align: bottom;
+}
+
+.chart-svg {
+  margin-left: 0px;
+  height: 3em;
 }
 
 .button-clicked {
-  filter: invert(1)
+  filter: invert(1);
 }

--- a/js/components/letters.json
+++ b/js/components/letters.json
@@ -106,7 +106,8 @@
     "is_script": true,
     "display": "ܟ",
     "script": "estrangela",
-    "leading_letter": "‍"
+    "leading_letter": "‍",
+    "glyph_file": "kaph.svg"
   },
   {
     "id": 20,
@@ -128,7 +129,8 @@
     "is_script": true,
     "display": "ܠ",
     "script": "estrangela",
-    "trailing_letter": "‍"
+    "trailing_letter": "‍",
+    "glyph_file": "lamadh.svg"
   },
   {
     "id": 23,
@@ -143,7 +145,8 @@
     "is_script": true,
     "display": "ܡ",
     "script": "estrangela",
-    "leading_letter": "‍"
+    "leading_letter": "‍",
+    "glyph_file": "mim.svg"
   },
   {
     "id": 27,
@@ -158,7 +161,8 @@
     "is_script": true,
     "display": "ܢ",
     "script": "estrangela",
-    "leading_letter": "‍"
+    "leading_letter": "‍",
+    "glyph_file": "nun.svg"
   },
   {
     "id": 30,
@@ -166,7 +170,8 @@
     "is_script": true,
     "display": "ܢ",
     "script": "estrangela",
-    "trailing_letter": "‍"
+    "trailing_letter": "‍",
+    "glyph_file": "nun_final.svg"
   },
   {
     "id": 31,
@@ -244,7 +249,8 @@
     "is_script": true,
     "display": "ܬ",
     "script": "serto",
-    "trailing_letter": "‍"
+    "trailing_letter": "‍",
+    "glyph_file": "taw_triangular.svg"
   },
   {
     "id": 42,

--- a/js/components/letters.json
+++ b/js/components/letters.json
@@ -90,7 +90,8 @@
     "display": "ܝ",
     "script": "estrangela",
     "leading_letter": "‍",
-    "trailing_letter": "‍"
+    "trailing_letter": "‍",
+    "glyph_file": "yudh_connected.svg"
   },
   {
     "id": 49,

--- a/src/assets/font_glyphs/kaph.svg
+++ b/src/assets/font_glyphs/kaph.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="0 0 889 2048">
+  <g transform="matrix(1 0 0 -1 0 1434)">
+   <path fill="currentColor"
+d="M862 2q-5 -2 -18 -2h-914v139h744q-216 307 -318 307q-28 0 -86 -24q-29 -11 -50.5 -17t-35.5 -6q-18 0 -34.5 6t-29 17t-20.5 26t-8 33q0 72 72 107q54 28 135 28q192 0 483 -387q54 -72 81.5 -118.5t27.5 -69.5q0 -33 -29 -39z" />
+  </g>
+
+</svg>

--- a/src/assets/font_glyphs/lamadh.svg
+++ b/src/assets/font_glyphs/lamadh.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="0 0 1118 2048">
+  <g transform="matrix(1 0 0 -1 0 1434)">
+   <path fill="currentColor"
+d="M1051 0q-51 0 -118 9.5t-151 29.5q-106 -20 -188.5 -29.5t-142.5 -9.5h-113q-77 0 -129 31q-66 37 -66 108q0 129 103 129q29 0 94 -65q64 -64 111 -64q282 0 282 99q0 72 -31 194.5t-94 296.5q-63 175 -94 300.5t-31 207.5q0 106 82 106q110 0 154 -243q11 -63 31 -184
+t51 -302q17 -96 29 -175t20 -142q5 -38 13 -64.5t22 -42.5q39 -51 233 -51v-139h-67z" />
+  </g>
+
+</svg>

--- a/src/assets/font_glyphs/mim.svg
+++ b/src/assets/font_glyphs/mim.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="0 0 1253 2048">
+  <g transform="matrix(1 0 0 -1 0 1434)">
+   <path fill="currentColor"
+d="M1034 -35q-83 0 -135 45q-53 47 -53 129q0 78 40 78q12 0 49 -57q46 -56 83 -56q49 0 65 41q11 27 11 84q0 35 -6.5 72.5t-18.5 75.5q-30 102 -84 102q-38 0 -90 -12q-58 -236 -270 -358q-189 -109 -449 -109h-246v139h86h134q109 0 196 14t152 40q88 35 146 97t89 150
+q-88 -20 -169.5 -29.5t-160.5 -9.5q-113 0 -245 45q-166 58 -166 150q0 113 84 113q22 0 59 -18.5t113 -53.5q149 -70 231 -70t246 33q82 17 143 26t103 9q150 0 223 -137q59 -112 59 -273q0 -260 -219 -260z" />
+  </g>
+
+</svg>

--- a/src/assets/font_glyphs/nun.svg
+++ b/src/assets/font_glyphs/nun.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="0 0 487 2048">
+  <g transform="matrix(1 0 0 -1 0 1434)">
+   <path fill="currentColor"
+d="M397 -2h-58q-58 0 -175 2h-234v139h283q46 0 55 6q21 10 21 48q0 29 -20 78t-58 116t-57 109.5t-19 64.5q0 24 8.5 45.5t22.5 37t33.5 25t42.5 9.5q88 0 137 -119q8 -22 21 -69.5t30 -122.5q29 -125 43 -194.5t14 -86.5q0 -88 -90 -88z" />
+  </g>
+
+</svg>

--- a/src/assets/font_glyphs/nun_final.svg
+++ b/src/assets/font_glyphs/nun_final.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="0 0 698 2048">
+  <g transform="matrix(1 0 0 -1 0 1434)">
+   <path fill="currentColor"
+d="M817 -631q-13 0 -141 96q-88 65 -167.5 134.5t-152.5 144.5q-213 219 -213 340q0 129 121 129q14 0 42.5 -9t70.5 -28q88 -37 129 -37h192v-139h-184q-36 0 -102 29q-29 3 -29 -29q0 -76 121 -227q38 -48 93.5 -110.5t129.5 -137.5q57 -60 88 -89.5t33 -47.5
+q0 -19 -31 -19z" />
+  </g>
+
+</svg>

--- a/src/assets/font_glyphs/taw_triangular.svg
+++ b/src/assets/font_glyphs/taw_triangular.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="0 0 1272 2048">
+  <g transform="matrix(1 0 0 -1 0 1638)">
+   <path fill="currentColor"
+d="M1272 0h-102q-191 0 -418 233q-204 210 -341 496q0 -347 -81 -552q91 -12 177 -40q139 -43 139 -94q0 -21 -61 -139q-156 102 -273 102q-61 0 -204 -64q130 209 168 311q55 146 55 359q0 41 -20 129q-20 83 -18 115q3 69 142 147q81 -192 148 -324.5t121 -208.5
+q223 -318 523 -318h45v-152z" />
+  </g>
+
+</svg>

--- a/src/assets/font_glyphs/yudh_connected.svg
+++ b/src/assets/font_glyphs/yudh_connected.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="0 0 618 2048">
+  <g transform="matrix(1 0 0 -1 0 1434)">
+   <path fill="currentColor"
+d="M-70 0v139h70q229 -3 229 19q-45 88 -67.5 142t-22.5 77q0 24 10.5 46t28 38.5t40.5 26.5t48 10q193 0 193 -262q0 -22 -1 -46.5t-3 -50.5h163v-139h-688z" />
+  </g>
+
+</svg>


### PR DESCRIPTION
There are seven Syriac medial or final letter forms that don't render properly as standalone letters in Chrome and Safari despite the use of tricks like zero-width joiner characters (which do work in Firefox). This PR adds SVG versions of those letters as well as code to display them properly on form buttons and in the scriptchart. They now look more or less indistinguishable from the font-rendered letters, but for consistency we could later convert **all** of the letters to SVGs, although it would be a pretty tedious task.