### PR TITLE
Configure `dotenv`

### DIFF
--- a/.env_template
+++ b/.env_template
@@ -1,0 +1,12 @@
+# API_ROOT
+#
+# Examples:
+#
+#  * For local development:
+#    API_ROOT=http://localhost:8000/api/
+#
+#  * For production use:
+#    API_ROOT=https://db.syriac.reclaim.hosting/api/
+#
+
+API_ROOT=<api_root>

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _site
 node_modules/
 src/assets/bundle.js
 src/mirador
+.env

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Based on [the Minimal React Webpack Babel Setup](https://www.robinwieruch.de/min
 
 - Run `bundle install`
 - Run `yarn`
+- Configure a `.env` file (see `.env_template` for details)
 
 ## Features
 

--- a/js/components/App.js
+++ b/js/components/App.js
@@ -50,8 +50,9 @@ import DashTabs from "./DashTabs";
 /* The maximum number of letter examples to load (and possibly show) */
 const MAX_EXAMPLES = 5;
 
-export const API_ROOT = "https://db.syriac.reclaim.hosting/api/";
-//export const API_ROOT = "http://localhost:8000/api/";
+// export const API_ROOT = "https://db.syriac.reclaim.hosting/api/";
+// export const API_ROOT = "http://localhost:8000/api/";
+export const API_ROOT = process.env.API_ROOT;
 
 class App extends Component {
   constructor(props) {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "babel-loader": "^8.0.5",
     "concurrently": "^4.1.0",
     "css-loader": "^2.1.0",
+    "dotenv-webpack": "^1.7.0",
     "enzyme": "^3.8.0",
     "enzyme-adapter-react-16": "^1.9.1",
     "enzyme-to-json": "^3.3.5",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const webpack = require("webpack");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 const path = require("path");
+const Dotenv = require('dotenv-webpack');
 
 module.exports = {
   entry: ["script-loader!mirador/dist/mirador.min", "./js/index.jsx"],
@@ -78,6 +79,7 @@ module.exports = {
         }
       ],
       { copyUnmodified: true }
-    )
+    ),
+    new Dotenv()
   ]
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4311,15 +4311,34 @@ dot-prop@^4.1.1:
   dependencies:
     is-obj "^1.0.0"
 
+dotenv-defaults@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/dotenv-defaults/-/dotenv-defaults-1.0.2.tgz#441cf5f067653fca4bbdce9dd3b803f6f84c585d"
+  integrity sha512-iXFvHtXl/hZPiFj++1hBg4lbKwGM+t/GlvELDnRtOFdjXyWP7mubkVr+eZGWG62kdsbulXAef6v/j6kiWc/xGA==
+  dependencies:
+    dotenv "^6.2.0"
+
 dotenv-expand@4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-4.2.0.tgz#def1f1ca5d6059d24a766e587942c21106ce1275"
   integrity sha1-3vHxyl1gWdJKdm5YeULCEQbOEnU=
 
+dotenv-webpack@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/dotenv-webpack/-/dotenv-webpack-1.7.0.tgz#4384d8c57ee6f405c296278c14a9f9167856d3a1"
+  integrity sha512-wwNtOBW/6gLQSkb8p43y0Wts970A3xtNiG/mpwj9MLUhtPCQG6i+/DSXXoNN7fbPCU/vQ7JjwGmgOeGZSSZnsw==
+  dependencies:
+    dotenv-defaults "^1.0.2"
+
 dotenv@6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.0.0.tgz#24e37c041741c5f4b25324958ebbc34bca965935"
   integrity sha512-FlWbnhgjtwD+uNLUGHbMykMOYQaTivdHEmYwAKFjn6GKe/CqY0fNae93ZHTd20snh9ZLr8mTzIL9m0APQ1pjQg==
+
+dotenv@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.2.0.tgz#941c0410535d942c8becf28d3f357dbd9d476064"
+  integrity sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==
 
 download@^6.2.2:
   version "6.2.5"


### PR DESCRIPTION
`dotenv` was already installed, it appears, just not correctly configured.  This commit adds it to `webpack.config.js`, adds some documentation, and uses it to supply the `API_HOST` constant in `App.js`.