### PR TITLE
Table scroll behavior

### DIFF
--- a/js/components/ColumnControls.js
+++ b/js/components/ColumnControls.js
@@ -35,29 +35,30 @@ class ColumnControls extends React.Component {
     let manifestDiv = "";
     if (this.props.manifestURL != null) {
       manifestDiv = (
-        <div className={"header-icon"}>
+        <div className="header-icon">
           <FontAwesomeIcon
             title="Show this manuscript in the Mirador viewer"
             color="#0000FF"
             icon="book-open"
             onClick={this.showManifest}
-            style={{ cursor: "pointer" }}
           />
         </div>
       );
     }
     return (
-      <div className={"flex-row"}>
-        <div
-          className={"header-icon"}
-          title="Hide this column"
-          className="remove"
-          onClick={this.hideColumn}
-          style={{ cursor: "pointer" }}
-        >
-          <b>&#10007;</b>
+      <div>
+        {this.props.shelfmark}
+        <div className="flex-row">
+          <span>{this.props.date ? `(${this.props.date})` : ""}</span>
+          {manifestDiv}
+          <div
+            title="Hide this column"
+            className="header-icon remove"
+            onClick={this.hideColumn}
+          >
+            <b>&#10007;</b>
+          </div>
         </div>
-        {manifestDiv}
       </div>
     );
   }

--- a/js/components/DragTable.js
+++ b/js/components/DragTable.js
@@ -2,30 +2,15 @@ import React from "react";
 
 /* DragTable - The lowest level of the scriptchart
  * component hierarchy; contains mostly boilerplate
- * implementation of the reactabular "sticky headers"
- * and "draggable rows/columns" features (custom behavior
+ * implementation of the reactabular
+ * "draggable rows/columns" features (custom behavior
  * is handled by its parent ScriptChart).
- *
- * XXX Currently has some issues with formatting: column
- * headers don't always match the witdh of their content
- * cells below, and the chart size/scrollbar capabilities
- * could use refinement.
  */
 
 import * as Table from "reactabular-table";
 import * as dnd from "reactabular-dnd";
-import * as Sticky from "reactabular-sticky";
 
 class DragTable extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.onScrollFromNative = this.onScrollFromNative.bind(this);
-  }
-
-  onScrollFromNative(e) {
-    this.tableHeader.scrollLeft = e.target.scrollLeft;
-  }
 
   render() {
     const renderers = {
@@ -41,45 +26,20 @@ class DragTable extends React.Component {
       column => !this.props.hiddenManuscripts.includes(column.props.msid)
     );
 
-    const tableStyle = {
-      clear: "none"
-    };
-    const tableHeaderStyle = {
-      overflow: "hidden"
-    };
-    const tableBodyStyle = {
-      overflow: "auto"
-    };
-
     return (
-      <Table.Provider
-        className="pure-table pure-table-striped"
-        style={{ overflowX: "auto" }}
-        renderers={renderers}
-        columns={columns}
-        style={tableStyle}
-      >
-        <Sticky.Header
-          style={tableHeaderStyle}
-          ref={tableHeader => {
-            this.tableHeader = tableHeader && tableHeader.getRef();
-          }}
-          tableBody={this.tableBody}
-        />
-        <Sticky.Body
-          rows={this.props.rows.filter(
-            row => !this.props.hiddenLetters.includes(row.ltid)
-          )}
-          rowKey="id"
-          onRow={this.props.onRow}
-          style={tableBodyStyle}
-          ref={tableBody => {
-            this.tableBody = tableBody && tableBody.getRef();
-          }}
-          tableHeader={this.tableHeader}
-          onScroll={this.onScrollFromNative}
-        />
-      </Table.Provider>
+      <div className="scriptchart-table-wrapper" >
+        <Table.Provider columns={columns} renderers={renderers}>
+          <Table.Header />
+
+          <Table.Body
+            rows={this.props.rows.filter(
+              row => !this.props.hiddenLetters.includes(row.ltid)
+            )}
+            rowKey="id"
+            onRow={this.props.onRow}
+          />
+        </Table.Provider>
+      </div>
     );
   }
 }

--- a/js/components/ScriptChart.js
+++ b/js/components/ScriptChart.js
@@ -54,33 +54,6 @@ class ScriptChart extends React.Component {
   getRows() {
     let rows = [];
 
-    /* Add row that will contain link to Mirador viewer, column hider Xs */
-    let colControls = { id: 0, ltid: "", letter: "", visible: true };
-
-    /* Add dates row */
-    let datesRow = {
-      id: 1,
-      ltid: "Date",
-      letter: "Date",
-      visible: !this.props.hiddenLetters.includes("Date")
-    };
-
-    for (let i = 0, len = this.props.columnManuscripts.length; i < len; i++) {
-      colControls["manuscript" + (i + 1)] = (
-        <ColumnControls
-          msid={this.props.columnManuscripts[i].id}
-          shelfmark={this.props.columnManuscripts[i].shelfmark}
-          manifestURL={this.props.columnManuscripts[i].manifest}
-          displayManifest={this.viewManifest}
-          onHideColumn={this.onHideColumn}
-          onHiddenChange={this.props.onHiddenChange}
-        />
-      );
-      datesRow["manuscript" + (i + 1)] = this.props.columnManuscripts[i].date;
-    }
-    rows.push(colControls);
-    rows.push(datesRow);
-
     /* Load the letters data into the rows array */
     for (let i = 0, len = this.props.rowLetters.length; i < len; i++) {
       let ltID = this.props.rowLetters[i].id;
@@ -175,7 +148,20 @@ class ScriptChart extends React.Component {
           props: {
             label: this.props.columnManuscripts[i].shelfmark,
             onMove: o => this.props.onColumnMove(o)
-          }
+          },
+          formatters: [
+            name => (
+              <ColumnControls
+                msid={this.props.columnManuscripts[i].id}
+                shelfmark={this.props.columnManuscripts[i].shelfmark}
+                date={this.props.columnManuscripts[i].date}
+                manifestURL={this.props.columnManuscripts[i].manifest}
+                displayManifest={this.viewManifest}
+                onHideColumn={this.onHideColumn}
+                onHiddenChange={this.props.onHiddenChange}
+              />
+            )
+          ]
         },
         visible: !this.props.hiddenManuscripts.includes(
           this.props.columnManuscripts[i].id

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "react-tabs": "^3.0.0",
     "react-transition-group": "1.2.1",
     "reactabular-dnd": "8.16.0",
-    "reactabular-sticky": "^8.14.0",
     "reactabular-table": "8.14.0",
     "reactjs-popup": "^1.3.2"
   },
@@ -68,18 +67,18 @@
     "copy-webpack-plugin": "^4.6.0",
     "css-loader": "^2.1.0",
     "dotenv-webpack": "^1.7.0",
+    "enzyme": "^3.8.0",
     "enzyme-adapter-react-16": "^1.9.1",
     "enzyme-to-json": "^3.3.5",
-    "enzyme": "^3.8.0",
+    "eslint": "^5.12.1",
     "eslint-config-prettier": "^4.0.0",
     "eslint-config-react-app": "^3.0.7",
     "eslint-plugin-prettier": "^3.0.1",
-    "eslint": "^5.12.1",
     "file-loader": "^3.0.1",
     "gh-pages": "^2.0.1",
     "image-webpack-loader": "^4.6.0",
-    "jest-serializer-enzyme": "^1.0.0",
     "jest": "^24.1.0",
+    "jest-serializer-enzyme": "^1.0.0",
     "lint-staged": "^8.1.1",
     "mini-css-extract-plugin": "^0.7.0",
     "node-sass": "^4.12.0",
@@ -92,10 +91,10 @@
     "script-loader": "^0.7.2",
     "style-loader": "^0.23.1",
     "url-loader": "^1.1.2",
+    "webpack": "^4.29.0",
     "webpack-cli": "^3.2.1",
     "webpack-dev-server": "^3.1.14",
-    "webpack-fix-style-only-entries": "^0.3.0",
-    "webpack": "^4.29.0"
+    "webpack-fix-style-only-entries": "^0.3.0"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/src/_sass/_components.scss
+++ b/src/_sass/_components.scss
@@ -27,6 +27,7 @@
 .header-icon {
   margin-left: 5px;
   margin-right: 5px;
+  cursor: pointer;
 }
 
 table th {

--- a/src/_sass/_scriptchart-table.scss
+++ b/src/_sass/_scriptchart-table.scss
@@ -15,4 +15,9 @@
     display: block;
     overflow-x: hidden;
   }
+
+  th span {
+    flex-grow: 1;
+    font-weight: normal;
+  }
 }

--- a/src/_sass/_scriptchart-table.scss
+++ b/src/_sass/_scriptchart-table.scss
@@ -1,0 +1,18 @@
+.scriptchart-table-wrapper {
+  display: flex;
+  height: 100%;
+
+  table {
+    display: flex;
+    flex-direction: column;
+  }
+
+  thead {
+    display: block;
+  }
+
+  tbody {
+    display: block;
+    overflow-x: hidden;
+  }
+}

--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -27,6 +27,7 @@ $danger: $navbar-background-color;
 @import "../_sass/layout.scss";
 @import "../_sass/app.scss";
 @import "../_sass/components.scss";
+@import "../_sass/scriptchart-table.scss";
 @import "./fonts/syriac_fonts.css";
 
 .navbar-brand .title {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11603,11 +11603,6 @@ reactabular-dnd@8.16.0:
   resolved "https://registry.yarnpkg.com/reactabular-dnd/-/reactabular-dnd-8.16.0.tgz#c66df1cfa08615978aa4eeb885747a1634dfc54a"
   integrity sha512-gU2j9A90+0phiQ4SJkNxBc7tht/St5uzIxAlb2ELVtpB6C5UsZ25uoeiasv/zi6LuBwaUiIeLWe092nYx0loBA==
 
-reactabular-sticky@^8.14.0:
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/reactabular-sticky/-/reactabular-sticky-8.14.0.tgz#28834976700eacfe509b0afb7205bc31e50be727"
-  integrity sha512-xVcByimsWTG47mPioMedzIZA/PUqq1s7tZTW1Ylv/QA+DMU6TJnkLe39u5RSkTOmLGn5HjadT1pyN1qAqaH3ig==
-
 reactabular-table@8.14.0:
   version "8.14.0"
   resolved "https://registry.yarnpkg.com/reactabular-table/-/reactabular-table-8.14.0.tgz#2ce05de47d499db91678fa9518505ea509bf3d7f"


### PR DESCRIPTION
** This is a draft pull request **

The first commit restores the original behaviour broken by my full-page layout changes.  However, two limitations remain: 1) the buttons and date rows are not sticky -- this is as originally the case, but would be nice to fix; 2) the vertical scrollbar for the table body disappears off the screen to the right -- this is still preferable to the original behaviour, but represents a regression of sorts from where we were before this first commit.

The second and third commits represent (potentially controversial) solutions to these problems, so I present them for discussion, consideration, and feedback.  We can implement, either, both, or neither.

The second commit moves the buttons and the date info into the column header row (I would like to move these rows into the `<thead/>`, but this is not possible with `reactabular`).  They could perhaps be arranged differently.

The third commit moves the vertical scrollbar on the table body to the left-hand side.  I'm not sure what this will look like on Macs with the magical vanishing scrollbars, and needs some testing.  It may just be a bridge too far.

`reactabular` offers some advanced options in these regards, but it's already pretty heavy, and removing some of its functionality already seems to make the table a bit more performant.  If we had another week or two, I'd like to drop `reactabular` altogether, and redevelop the subset of functionality we need in a super-lean way.  But not now.