### PR TITLE
Dont' show thumbnails on newly added manuscripts

### DIFF
--- a/js/components/DashTabs.js
+++ b/js/components/DashTabs.js
@@ -229,7 +229,7 @@ class DashTabs extends React.Component {
           targetSlot: targetSlot,
           viewType: "ImageView",
           sidePanel: false,
-          displayLayout: false,
+          displayLayout: true,
           bottomPanel: false,
           canvasControls: {
             annotations: {
@@ -246,8 +246,6 @@ class DashTabs extends React.Component {
 
   onManifestSelected(selectedManifestURI) {
     let manifestURIs = [...this.state.manifestURIs];
-    let windowObjects = [...this.state.windowObjects];
-    let miradorLayout = this.state.miradorLayout;
 
     if (manifestURIs.length == 0 && this.props.manuscripts) {
       [
@@ -257,39 +255,22 @@ class DashTabs extends React.Component {
       ] = this.getMiradorParameters();
     }
 
-    // If the selected manifest is already being shown in the viewer, do nothing.
-    if (
-      windowObjects.findIndex(o => o.loadedManifest == selectedManifestURI) < 0
-    ) {
-      // Otherwise, treat the Mirador viewer windows as a FIFO queue of size 1-4
-      if (windowObjects.length == 4) {
-        windowObjects.pop();
-      }
-      let windowObject = {
-        loadedManifest: selectedManifestURI,
-        targetSlot: "row1.column1",
-        viewType: "ImageView",
-        sidePanel: false
-      };
-      windowObjects.unshift(windowObject);
-
-      for (let m = 1, len = windowObjects.length; m < len; m++) {
-        if (m == 1) {
-          windowObjects[m]["targetSlot"] = "row1.column2";
-        } else if (m == 2) {
-          windowObjects[m]["targetSlot"] = "row2.column1";
-        } else if (m == 3) {
-          windowObjects[m]["targetSlot"] = "row2.column2";
+    let windowObjects = [{
+      loadedManifest: selectedManifestURI,
+      targetSlot: "row1.column1",
+      viewType: "ImageView",
+      sidePanel: false,
+      displayLayout: true,
+      bottomPanel: false,
+      canvasControls: {
+        annotations: {
+          annotationLayer: false,
+          annotationCreation: false
         }
       }
+    }];
 
-      let miradorLayout = "1x1";
-      if (windowObjects.length == 2) {
-        miradorLayout = "1x2";
-      } else if (windowObjects.length >= 3) {
-        miradorLayout = "2x2";
-      }
-    }
+    let miradorLayout = "1x1";
 
     this.setState({ manifestURIs, windowObjects, miradorLayout, tabIndex: 1 });
   }


### PR DESCRIPTION
Despite the name, this PR mostly just reinforces/simplifies previous behavior regarding the Mirador viewer. In response to feedback from Michael, the Mirador layout panel (the one that allows users to add new manifests to the viewer from within Mirador) remains disabled, and in light of the discovery that Mirador mostly ignores the `targetSlot` layout directives, the layout positioning code is simplified.
Also, the "zen mode" Mirador window settings are applied to newly displayed manuscripts (beyond the original 4) so that this manuscript also does not appear with thumbnails in its frame.