### PR TITLE
Use cursor to indicate draggables

### DIFF
--- a/src/_sass/_scriptchart-table.scss
+++ b/src/_sass/_scriptchart-table.scss
@@ -20,4 +20,8 @@
     flex-grow: 1;
     font-weight: normal;
   }
+
+  th[msid][draggable], tr[draggable] {
+    cursor: move;
+  }
 }


### PR DESCRIPTION
This is a one-line css commit, but it might as well go in in time for the next deploy.

Note:: I'm going with `move` rather than `grab` (which would otherwise be better imo) because I haven't looked in to changing it to `grabbing` when the drag is activated. (Note also that `move` and `grab` are rendered the same way in most browsers anyway.)  A proper solution will involve looking at the `reactabular-dnd` docs and changing css on drag for dropzone etc.