### PR TITLE
Correct vertical alignment issue caused by CIDR "I" icon in footer

### DIFF
--- a/src/_includes/footer.html
+++ b/src/_includes/footer.html
@@ -12,10 +12,16 @@
       </a>
     </span>
   </div>
-  <div>
+  <div >
     <span>
       <a href="http://cidr.stanford.edu/" title="Center for Interdisciplinary Digital Research @ Stanford Libraries">
         A SUL-CIDR Project
+      </a>
+    </span>
+  </div>
+  <div >
+    <span>
+      <a href="http://cidr.stanford.edu/" title="Center for Interdisciplinary Digital Research @ Stanford Libraries">
         <img src="{{ "/assets/img/cidr_i.png" | relative_url }}" alt="CIDR logo"/>
       </a>
     </span>

--- a/src/_includes/footer.html
+++ b/src/_includes/footer.html
@@ -12,14 +12,14 @@
       </a>
     </span>
   </div>
-  <div >
+  <div>
     <span>
       <a href="http://cidr.stanford.edu/" title="Center for Interdisciplinary Digital Research @ Stanford Libraries">
         A SUL-CIDR Project
       </a>
     </span>
   </div>
-  <div >
+  <div>
     <span>
       <a href="http://cidr.stanford.edu/" title="Center for Interdisciplinary Digital Research @ Stanford Libraries">
         <img src="{{ "/assets/img/cidr_i.png" | relative_url }}" alt="CIDR logo"/>

--- a/src/_sass/_layout.scss
+++ b/src/_sass/_layout.scss
@@ -61,6 +61,7 @@ body {
   display: flex;
   min-height: 35px;
   align-items: center;
+  justify-content: space-between;
   color: $navbar-item-color;
   padding: 0 1%;
   line-height: 1;
@@ -74,23 +75,13 @@ body {
     }
   }
 
-  div {
-    flex: 1;
-    display: flex;
-    justify-content: center;
+  div:nth-child(2) {
+    margin-left: auto;
+    margin-right: auto;
+  } 
 
-    &:first-child > span {
-      margin-right: auto;
-    }
-
-    &:nth-child(2) {
-      text-align: center;
-    }
-
-    &:last-child  > span {
-      margin-left: auto;
-      text-align: right;
-    }
+  div:nth-child(3) {
+    margin-left: auto;
   }
 
   img {


### PR DESCRIPTION
When the text "A SUL-CIDR Project" and the CIDR mini-I icon are in the same div in the flexbox layout, the height of the icon tends to push the vertical positioning of the text out of the alignment with the rest of the footer. Placing them in separate divs with the appropriate justification settings fixes this, with the side effect that the icon doesn't glow when the text is hovered and vice versa. Still, I think it's better this way.