### PR TITLE
Use reactjs-popup for bookmark modal popup

### DIFF
--- a/js/components/BookmarkModal.js
+++ b/js/components/BookmarkModal.js
@@ -1,9 +1,7 @@
 import React from "react";
-import Modal from "react-modal";
+import Popup from "reactjs-popup";
 
 import { CopyToClipboard } from "react-copy-to-clipboard";
-
-Modal.setAppElement("#content");
 
 class BookmarkModal extends React.Component {
   constructor(props) {
@@ -16,22 +14,17 @@ class BookmarkModal extends React.Component {
 
   render() {
     return (
-      <Modal
-        isOpen={this.props.isOpen}
-        onRequestClose={this.props.closeModal}
-        shouldCloseOnOverlayClick={true}
-        className="Modal"
-        overlayClassName="Overlay"
-        contentLabel="Bookmark URL"
+      <Popup
+        open={this.props.isOpen}
+        closeOnDocumentClick
+        onClose={this.props.closeModal}
       >
-        <div className={"modal_header"}>
-          <b>Bookmark</b>
-          <button className={"button is-small"} onClick={this.props.closeModal}>
-            Close
-          </button>
-        </div>
-        <div className={"field box"}>
-          <div className={"control"}>
+        <div className="bookmark-modal">
+          <a className="close" onClick={this.props.closeModal}>
+            &times;
+          </a>
+          <div className="header">Bookmark URL</div>
+          <div className="control">
             <div className="bookmarktext">{this.props.bookmarkURL}</div>
             <CopyToClipboard
               text={this.props.bookmarkURL}
@@ -41,13 +34,12 @@ class BookmarkModal extends React.Component {
                 <button className={"button is-info"}>Copy to clipboard</button>
               </div>
             </CopyToClipboard>
+            {this.state.copied ? (
+              <p className={"has-text-success is-large"}>Copied.</p>
+            ) : null}
           </div>
-
-          {this.state.copied ? (
-            <p className={"has-text-success is-large"}>Copied.</p>
-          ) : null}
         </div>
-      </Modal>
+      </Popup>
     );
   }
 }

--- a/js/components/BookmarkModal.js
+++ b/js/components/BookmarkModal.js
@@ -10,6 +10,13 @@ class BookmarkModal extends React.Component {
     this.state = {
       copied: false
     };
+
+    this.closeModal = this.closeModal.bind(this);
+  }
+
+  closeModal() {
+    this.setState({ copied: false });
+    this.props.closeModal();
   }
 
   render() {
@@ -20,20 +27,22 @@ class BookmarkModal extends React.Component {
         onClose={this.props.closeModal}
       >
         <div className="bookmark-modal">
-          <a className="close" onClick={this.props.closeModal}>
-            &times;
-          </a>
-          <div className="header">Bookmark URL</div>
+          <div className="header">
+            Bookmark URL
+            <button className="button is-small" onClick={this.closeModal}>
+              Close
+            </button>
+          </div>
           <div className="control">
             <div className="bookmarktext">{this.props.bookmarkURL}</div>
-            <CopyToClipboard
-              text={this.props.bookmarkURL}
-              onCopy={() => this.setState({ copied: true })}
-            >
-              <div className={"box has-text-centered"}>
+            <div className={"box has-text-centered"}>
+              <CopyToClipboard
+                text={this.props.bookmarkURL}
+                onCopy={() => this.setState({ copied: true })}
+              >
                 <button className={"button is-info"}>Copy to clipboard</button>
-              </div>
-            </CopyToClipboard>
+              </CopyToClipboard>
+            </div>
             {this.state.copied ? (
               <p className={"has-text-success is-large"}>Copied.</p>
             ) : null}

--- a/js/components/DashTabs.js
+++ b/js/components/DashTabs.js
@@ -447,8 +447,8 @@ class DashTabs extends React.Component {
       >
         <BookmarkModal
           isOpen={this.state.bookmarkIsOpen}
-          closeModal={this.closeModal}
           bookmarkURL={this.state.bookmarkURL}
+          closeModal={this.closeModal}
         />
         <TabList>
           <Tab>

--- a/js/components/__tests__/BookmarkModal.js
+++ b/js/components/__tests__/BookmarkModal.js
@@ -1,0 +1,13 @@
+/* eslint-disable import/no-extraneous-dependencies */
+/* eslint-disable no-undef */
+import React from "react";
+import renderer from "react-test-renderer";
+import BookmarkModal from "../BookmarkModal";
+
+describe("BookmarkModal test", () => {
+  it("BookmarkModal should match snapshot", () => {
+    const component = renderer.create(<BookmarkModal />);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/js/components/__tests__/__snapshots__/App.test.js.snap
+++ b/js/components/__tests__/__snapshots__/App.test.js.snap
@@ -864,6 +864,7 @@ exports[`App test App should match snapshot 1`] = `
                 <input
                   checked={true}
                   id="hoverContext"
+                  name="contextMode"
                   onChange={[Function]}
                   type="radio"
                   value="hover"
@@ -880,6 +881,7 @@ exports[`App test App should match snapshot 1`] = `
                 <input
                   checked={false}
                   id="clickContext"
+                  name="contextMode"
                   onChange={[Function]}
                   type="radio"
                   value="click"
@@ -952,40 +954,51 @@ exports[`App test App should match snapshot 1`] = `
   <div
     className="scriptchart"
   >
-    <div>
-      <h2
-        className="subtitle is-4"
+    <div
+      className="help-text box"
+    >
+      <h5
+        className="subtitle is-5"
       >
-        Here's a quick guide to using the options form. For full help documentation, see our 
+        Please select one or more manuscripts and letters from the options menu, then click the "Submit" button.
+      </h5>
+      <hr />
+      <p
+        className="content"
+      >
+        Here's a quick guide to using the scriptchart and options form. For full help documentation, see our
+         
         <a
           href="../guide/"
         >
-          how-to guide
+          How-to Guide
         </a>
         .
-      </h2>
-      <img
-        className="tutorial-image"
-        src={
-          Object {
-            "0": "t",
-            "1": "e",
-            "10": "s",
-            "11": "t",
-            "12": "u",
-            "13": "b",
-            "2": "s",
-            "3": "t",
-            "4": "-",
-            "5": "f",
-            "6": "i",
-            "7": "l",
-            "8": "e",
-            "9": "-",
-            "default": "test-file-stub",
-          }
-        }
-      />
+      </p>
+      <article
+        className="message"
+      >
+        <div
+          className="message-body"
+        >
+          <img
+            alt="Explanation of DASH Tabs"
+            src="../assets/img/help-images/dash-tabs.png"
+          />
+        </div>
+      </article>
+      <article
+        className="message"
+      >
+        <div
+          className="message-body"
+        >
+          <img
+            alt="Explanation of DASH Options Panel"
+            src="../assets/img/help-images/options-annotated.png"
+          />
+        </div>
+      </article>
     </div>
   </div>
 </div>

--- a/js/components/__tests__/__snapshots__/BookmarkModal.js.snap
+++ b/js/components/__tests__/__snapshots__/BookmarkModal.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BookmarkModal test BookmarkModal should match snapshot 1`] = `null`;

--- a/js/components/__tests__/__snapshots__/DashTabs.test.js.snap
+++ b/js/components/__tests__/__snapshots__/DashTabs.test.js.snap
@@ -78,6 +78,19 @@ exports[`DashTabs test DashTabs should match snapshot 1`] = `
     >
       Hidden Items
     </li>
+    <span>
+      <button
+        className="button is-info is-outlined"
+        onClick={[Function]}
+        style={
+          Object {
+            "verticalAlign": "bottom",
+          }
+        }
+      >
+        Bookmark
+      </button>
+    </span>
   </ul>
   <div
     aria-labelledby="react-tabs-0"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "react-dnd": "^2.6.0",
     "react-dnd-html5-backend": "7.0.2",
     "react-dom": "^16.6.3",
-    "react-modal": "^3.8.1",
     "react-scripts": "^2.1.3",
     "react-sidebar": "3.0.2",
     "react-tabs": "^3.0.0",

--- a/src/_sass/_app.scss
+++ b/src/_sass/_app.scss
@@ -23,23 +23,23 @@
     padding: 10px 10px 10px 10px;
 }
 
-.Modal {
-    position: absolute;
-    top: 30vh;
-    left: 30vw;
-    right: 30vw;
-    background-color: whitesmoke;
-    z-index: 100;
+.bookmark-modal {
+    font-size: 12px;
 }
-
-.Overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: rgba(54, 54, 54, 0.6);
-    z-index: 32;
+.bookmark-modal > .header {
+    width: 100%;
+    font-size: 18px;
+    text-align: center;
+    padding: 5px;
+}
+.bookmark-modal > .close {
+    cursor: pointer;
+    position: absolute;
+    display: block;
+    padding: 2px 5px;
+    line-height: 20px;
+    font-size: 24px;
+    background: #ffffff;
 }
 
 .bookmarktext {
@@ -48,11 +48,4 @@
     width: 100%;
     min-height: 5em;
     overflow: auto;
-}
-
-.modal_header {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    padding: 5px 5px 5px 5px;
 }

--- a/src/_sass/_app.scss
+++ b/src/_sass/_app.scss
@@ -27,9 +27,10 @@
     font-size: 12px;
 }
 .bookmark-modal > .header {
-    width: 100%;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
     font-size: 18px;
-    text-align: center;
     padding: 5px;
 }
 .bookmark-modal > .close {


### PR DESCRIPTION
This should be a drop-in replacement, with minimal changes to appearance and no changes to functionality. `reactjs-popup` is already used for the scriptchart popup images, so removing the extra modal library will lighten the app a bit, with the added bonus that the new modal doesn't break the snapshot tests, unlike the old one.