### PR TITLE
Remove double slashes from paths in meta tags

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,7 +17,7 @@ title: Digital Analysis of Syriac Handwriting
 #email: your-email@example.com
 description: >- # this means to ignore newlines until "url:"
   DASH: Digital Analysis of Syriac Handwriting
-url: https://dash.stanford.edu/ # the base hostname & protocol for your site, e.g. http://example.com
+url: https://dash.stanford.edu # the base hostname & protocol for your site, e.g. http://example.com
 baseurl: "/" # the subpath of your site, e.g. /blog
 repository: "sul-cidr/scriptchart"
 # Google Analytics

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "homepage": "https://sul-cidr.github.io/scriptchart",
   "main": "index.js",
   "scripts": {
-    "build": "bundle exec jekyll clean && JEKYLL_ENV=production bundle exec jekyll build && NODE_ENV=production node_modules/.bin/webpack -p",
+    "build": "bundle exec jekyll clean && JEKYLL_ENV=production bundle exec jekyll build --baseurl scriptchart && NODE_ENV=production node_modules/.bin/webpack -p",
     "dev": "yarn concurrently \"bundle exec jekyll serve --baseurl /scriptchart\" \"node_modules/.bin/webpack --watch\"",
     "precommit": "lint-staged",
-    "deploy": "bundle exec jekyll clean && JEKYLL_ENV=production bundle exec jekyll build --baseurl /scriptchart && NODE_ENV=production node_modules/.bin/webpack -p && gh-pages -d _site",
+    "deploy": "bundle exec jekyll clean && JEKYLL_ENV=production bundle exec jekyll build --baseurl scriptchart && NODE_ENV=production node_modules/.bin/webpack -p && gh-pages -d _site",
     "test": "node_modules/.bin/jest",
     "test:update": "node_modules/.bin/jest -u",
     "coverage": "node_modules/.bin/jest --coverage"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "DASH",
   "version": "0.0.1",
   "description": "Repository for the DASH project on Syriac manuscripts",
-  "homepage": "https://sul-cidr.github.io/scriptchart",
+  "homepage": "https://dash.stanford.edu",
   "main": "index.js",
   "scripts": {
     "build": "bundle exec jekyll clean && JEKYLL_ENV=production bundle exec jekyll build --baseurl scriptchart && NODE_ENV=production node_modules/.bin/webpack -p",


### PR DESCRIPTION
These updates remove the double slashes that were appearing in the URLs in meta tags on the site pages, e.g., `"url":"https://dash.stanford.edu//scriptchart/"`.
The changes have been tested locally and on the deployed github-pages site, but the full site functionality should be checked immediately upon deployment to production, as an errant slash in these config settings has been known to break the entire front-end.