### PR TITLE
avoid CircleCI build when deploying to gh-pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "bundle exec jekyll clean && JEKYLL_ENV=prod bundle exec jekyll build && NODE_ENV=production node_modules/.bin/webpack -p",
     "dev": "yarn concurrently \"bundle exec jekyll serve --baseurl /scriptchart\" \"node_modules/.bin/webpack --watch\"",
     "precommit": "lint-staged",
-    "deploy": "bundle exec jekyll clean && JEKYLL_ENV=production bundle exec jekyll build --baseurl /scriptchart && NODE_ENV=production node_modules/.bin/webpack -p && gh-pages -d _site",
+    "deploy": "bundle exec jekyll clean && JEKYLL_ENV=production bundle exec jekyll build --baseurl /scriptchart && NODE_ENV=production node_modules/.bin/webpack -p && gh-pages -d _site -m 'deploy [ci skip]'",
     "test": "node_modules/.bin/jest",
     "test:update": "node_modules/.bin/jest -u",
     "coverage": "node_modules/.bin/jest --coverage"


### PR DESCRIPTION
Added an argument to the `gh-pages` npm module so that when run via `yarn deploy`, it tells CircleCI not to run on the `gh-pages` branch. These attempts always fail because there is no CircleCI configuration for the `gh-pages` branch, and in most cases the `yarn deploy` already is being run from within a CircleCI job (triggered by a commit to develop).